### PR TITLE
Make BootForge validation and Rust gates trustworthy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
     - name: Format
       run: cargo fmt -- --check
+    - name: Lint
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+    - name: Build
+      run: cargo build --workspace --all-targets --verbose
+    - name: Run tests
+      run: cargo test --workspace --all-targets --verbose

--- a/.github/workflows/compliance-guard.yml
+++ b/.github/workflows/compliance-guard.yml
@@ -5,9 +5,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Forbidden Language Scan
+      - name: Public UI Language Scan
+        shell: bash
         run: |
-          grep -RInE "(bypass|unlock|jailbreak|root)" . && exit 1 || exit 0
+          set -euo pipefail
+          scan_roots=(apps/workshop-ui/src apps/forgeworks-core/src-tauri/src)
+          if grep -RInE "\b(bypass|unlock|jailbreak|root)\b" "${scan_roots[@]}" \
+            --exclude-dir=target \
+            --exclude='*.md'; then
+            echo "Forbidden language found in a public user interface."
+            exit 1
+          fi
       - name: Pandora Isolation
+        shell: bash
         run: |
-          grep -RIn "pandora-codex" apps services docs && exit 1 || exit 0
+          set -euo pipefail
+          if grep -RIn "pandora-codex" apps services; then
+            echo "Pandora Codex must not be referenced by public application or service code."
+            exit 1
+          fi

--- a/apps/forgeworks-core/src-tauri/src/lib.rs
+++ b/apps/forgeworks-core/src-tauri/src/lib.rs
@@ -142,7 +142,7 @@ mod tests {
 
         assert!(report.audit_integrity_verified);
         assert_eq!(report.audit_entries.len(), 4);
-        assert_eq!(report.device.non_invasive, true);
+        assert!(report.device.non_invasive);
     }
 
     #[test]

--- a/libbootforge/src/bin/bootforge-cli.rs
+++ b/libbootforge/src/bin/bootforge-cli.rs
@@ -79,7 +79,7 @@ impl CliOptions {
                 "--mode" => {
                     i += 1;
                     if i < args.len() {
-                        if let Some(mode) = DeviceMode::from_str(&args[i]) {
+                        if let Some(mode) = DeviceMode::parse(&args[i]) {
                             options.mode_filter = Some(mode);
                         } else {
                             eprintln!("Error: Invalid mode '{}'. Valid modes: normal, recovery, dfu, bootloader, fastboot, adb, massstorage", args[i]);

--- a/libbootforge/src/detect/scanner.rs
+++ b/libbootforge/src/detect/scanner.rs
@@ -139,10 +139,7 @@ fn read_string_descriptor<T: UsbContext>(
         return None;
     }
 
-    match handle.read_string_descriptor_ascii(index) {
-        Ok(s) => Some(s),
-        Err(_) => None,
-    }
+    handle.read_string_descriptor_ascii(index).ok()
 }
 
 #[cfg(test)]

--- a/libbootforge/src/types.rs
+++ b/libbootforge/src/types.rs
@@ -36,7 +36,7 @@ pub enum DeviceMode {
 
 impl DeviceMode {
     /// Parse mode from string (for CLI)
-    pub fn from_str(s: &str) -> Option<Self> {
+    pub fn parse(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "normal" => Some(DeviceMode::Normal),
             "recovery" => Some(DeviceMode::Recovery),

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -77,44 +77,47 @@ fi
 # Test 4: Project builds successfully
 echo ""
 echo "4. Testing project build..."
-if cargo build --quiet 2>&1 | grep -q "error"; then
-    fail "Project build failed"
-else
+if cargo build --quiet; then
     pass "Project builds successfully"
+else
+    fail "Project build failed"
 fi
 
 # Test 5: Core library (libbootforge) builds
 echo ""
 echo "5. Testing libbootforge library..."
-if cargo build -p libbootforge --quiet 2>&1 | grep -q "error"; then
-    fail "libbootforge build failed"
-else
+if cargo build -p libbootforge --quiet; then
     pass "libbootforge builds successfully"
+else
+    fail "libbootforge build failed"
 fi
 
 # Test 6: CLI binary builds
 echo ""
 echo "6. Testing bootforge-cli binary..."
-if cargo build --bin bootforge-cli --quiet 2>&1 | grep -q "error"; then
-    fail "bootforge-cli build failed"
-else
+if cargo build --bin bootforge-cli --quiet; then
     pass "bootforge-cli builds successfully"
+else
+    fail "bootforge-cli build failed"
 fi
 
 # Test 7: Unit tests pass
 echo ""
 echo "7. Running unit tests..."
-if cargo test --lib -p libbootforge --quiet 2>&1 | grep -q "test result: FAILED"; then
-    fail "libbootforge unit tests failed"
-else
+if cargo test --lib -p libbootforge --quiet; then
     pass "libbootforge unit tests pass"
+else
+    fail "libbootforge unit tests failed"
 fi
 
 # Test 8: USB detection capability
 echo ""
 echo "8. Testing USB device detection..."
-if cargo run --bin bootforge-cli --quiet 2>&1 | grep -qE "(Device|USB|VID|PID|No devices)" || \
-   cargo run --bin bootforge-cli --quiet 2>/dev/null >/dev/null; then
+CLI_OUTPUT=$(cargo run --bin bootforge-cli --quiet 2>&1)
+CLI_STATUS=$?
+if [ $CLI_STATUS -ne 0 ]; then
+    fail "USB detection command failed"
+elif echo "$CLI_OUTPUT" | grep -qE "(Device|USB|VID|PID|No devices)"; then
     pass "USB detection capability confirmed"
 else
     warn "USB detection test inconclusive (may require connected devices)"
@@ -123,7 +126,9 @@ fi
 # Test 9: No write operations in binary
 echo ""
 echo "9. Verifying read-only safety..."
-if strings target/debug/bootforge-cli 2>/dev/null | grep -qiE "(write_bulk|write_control|format|erase|flash)"; then
+if [ ! -f target/debug/bootforge-cli ]; then
+    fail "bootforge-cli binary unavailable for read-only inspection"
+elif strings target/debug/bootforge-cli 2>/dev/null | grep -qiE "(write_bulk|write_control|format|erase|flash)"; then
     warn "Potential write operations found in binary (manual review needed)"
 else
     pass "No obvious write operations detected in binary"
@@ -132,7 +137,7 @@ fi
 # Test 10: Audit logging service
 echo ""
 echo "10. Testing audit logging service..."
-if cargo test -p audit-logging --lib --quiet 2>&1 | grep -qE "test result: (ok|FAILED)"; then
+if cargo test -p audit-logging --lib --quiet; then
     pass "Audit logging service tests completed"
 else
     fail "Audit logging service tests failed"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -35,39 +35,43 @@ fail() {
     ((TESTS_FAILED++))
 }
 
+warn() {
+    echo -e "${YELLOW}⚠${NC} $1"
+}
+
 # Test 1: Workspace builds
 echo "1. Building workspace (debug)..."
-if cargo build 2>&1 | grep -q "error:"; then
-    fail "Workspace build failed"
-else
+if cargo build; then
     pass "Workspace builds successfully"
+else
+    fail "Workspace build failed"
 fi
 
 # Test 2: Release build
 echo ""
 echo "2. Building workspace (release)..."
-if cargo build --release 2>&1 | grep -q "error:"; then
-    fail "Release build failed"
-else
+if cargo build --release; then
     pass "Release build successful"
+else
+    fail "Release build failed"
 fi
 
 # Test 3: libbootforge library
 echo ""
 echo "3. Testing libbootforge library..."
-if cargo build -p libbootforge --lib 2>&1 | grep -q "error:"; then
-    fail "libbootforge library build failed"
-else
+if cargo build -p libbootforge --lib; then
     pass "libbootforge library builds"
+else
+    fail "libbootforge library build failed"
 fi
 
 # Test 4: bootforge-cli binary
 echo ""
 echo "4. Testing bootforge-cli binary..."
-if cargo build --bin bootforge-cli 2>&1 | grep -q "error:"; then
-    fail "bootforge-cli binary build failed"
-else
+if cargo build --bin bootforge-cli; then
     pass "bootforge-cli binary builds"
+else
+    fail "bootforge-cli binary build failed"
 fi
 
 # Test 5: Examples compile
@@ -81,10 +85,10 @@ for example in libbootforge/examples/*.rs; do
         EXAMPLE_NAME=$(basename "$example" .rs)
         ((EXAMPLES_TOTAL++))
 
-        if cargo build --example "$EXAMPLE_NAME" 2>&1 | grep -q "error:"; then
-            fail "Example '$EXAMPLE_NAME' failed to build"
-        else
+        if cargo build --example "$EXAMPLE_NAME"; then
             ((EXAMPLES_PASSED++))
+        else
+            fail "Example '$EXAMPLE_NAME' failed to build"
         fi
     fi
 done
@@ -100,10 +104,10 @@ fi
 # Test 6: Unit tests
 echo ""
 echo "6. Running unit tests..."
-if cargo test --lib --workspace --quiet 2>&1 | grep -q "test result: FAILED"; then
-    fail "Unit tests failed"
-else
+if cargo test --lib --workspace --quiet; then
     pass "Unit tests pass"
+else
+    fail "Unit tests failed"
 fi
 
 # Test 7: Services build
@@ -113,10 +117,10 @@ SERVICES=("device-analysis" "ownership-verification" "legal-classification" "aud
 SERVICES_PASSED=0
 
 for service in "${SERVICES[@]}"; do
-    if cargo build -p "$service" --quiet 2>&1 | grep -q "error:"; then
-        fail "Service '$service' build failed"
-    else
+    if cargo build -p "$service" --quiet; then
         ((SERVICES_PASSED++))
+    else
+        fail "Service '$service' build failed"
     fi
 done
 
@@ -130,7 +134,8 @@ fi
 echo ""
 echo "8. Testing CLI entrypoint..."
 CLI_OUTPUT=$(cargo run --bin bootforge-cli -- --help 2>&1)
-if echo "$CLI_OUTPUT" | grep -qiE "(bootforge|usage|options|--help)"; then
+CLI_STATUS=$?
+if [ $CLI_STATUS -eq 0 ] && echo "$CLI_OUTPUT" | grep -qiE "(bootforge|usage|options|--help)"; then
     pass "CLI entrypoint works (--help flag)"
 else
     fail "CLI entrypoint failed"
@@ -139,19 +144,19 @@ fi
 # Test 9: Code formatting
 echo ""
 echo "9. Checking code formatting..."
-if cargo fmt --check 2>&1 | grep -q "Diff"; then
-    fail "Code formatting check failed (run: cargo fmt)"
-else
+if cargo fmt --check; then
     pass "Code is properly formatted"
+else
+    fail "Code formatting check failed (run: cargo fmt)"
 fi
 
 # Test 10: Clippy lints (warnings allowed for smoke test)
 echo ""
 echo "10. Running clippy lints..."
-if cargo clippy --workspace --quiet 2>&1 | grep -q "error:"; then
-    fail "Clippy found errors"
+if cargo clippy --workspace --all-targets --all-features -- -D warnings; then
+    pass "Clippy checks pass with warnings denied"
 else
-    pass "Clippy checks pass (warnings may exist)"
+    fail "Clippy found errors"
 fi
 
 # Summary

--- a/services/auth/src/roles.rs
+++ b/services/auth/src/roles.rs
@@ -5,6 +5,12 @@ pub struct RoleManager {
     roles: HashSet<String>,
 }
 
+impl Default for RoleManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RoleManager {
     pub fn new() -> Self {
         RoleManager {

--- a/services/authority-routing/src/lib.rs
+++ b/services/authority-routing/src/lib.rs
@@ -159,7 +159,6 @@ pub fn generate_routing_result(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use device_analysis::RiskLevel;
     use legal_classification::{AuthorizationType, Jurisdiction, LegalStatus};
 
     #[test]

--- a/services/device-analysis/src/lib.rs
+++ b/services/device-analysis/src/lib.rs
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn test_analyze_device() {
         let result = analyze("iPhone 13 Pro - Clean device");
-        assert_eq!(result.non_invasive, true);
+        assert!(result.non_invasive);
         assert_eq!(result.classification, DeviceClassification::Clean);
     }
 
@@ -203,7 +203,7 @@ mod tests {
     #[test]
     fn test_always_non_invasive() {
         let result = analyze("Any device metadata");
-        assert_eq!(result.non_invasive, true);
+        assert!(result.non_invasive);
     }
 
     #[test]
@@ -236,7 +236,7 @@ mod tests {
         };
 
         let profile = analyze_usb_device(&device);
-        assert_eq!(profile.non_invasive, true);
+        assert!(profile.non_invasive);
         assert_eq!(profile.manufacturer, "Apple Inc.");
         assert_eq!(profile.classification, DeviceClassification::Clean);
     }

--- a/services/legal-classification/src/loader.rs
+++ b/services/legal-classification/src/loader.rs
@@ -21,12 +21,11 @@ pub struct JurisdictionMap {
  * Load jurisdiction map from JSON file
  */
 pub fn load_jurisdiction(code: &str) -> Result<JurisdictionMap, String> {
-    let file_path = format!(
-        "services/legal-classification/jurisdiction-map/{}.json",
-        code.to_lowercase()
-    );
+    let file_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("jurisdiction-map")
+        .join(format!("{}.json", code.to_lowercase()));
 
-    if !Path::new(&file_path).exists() {
+    if !file_path.exists() {
         return Err(format!("Jurisdiction map not found: {}", code));
     }
 

--- a/services/ownership-verification/src/lib.rs
+++ b/services/ownership-verification/src/lib.rs
@@ -145,7 +145,11 @@ mod tests {
             user_id: "user123".to_string(),
             device_id: device.device_id.clone(),
             attestation_type: AttestationType::CourtOrder,
-            documentation_references: vec!["doc1".to_string(), "doc2".to_string()],
+            documentation_references: vec![
+                "doc1".to_string(),
+                "doc2".to_string(),
+                "doc3".to_string(),
+            ],
             timestamp: Utc::now(),
         };
 


### PR DESCRIPTION
## What changed

### Trustworthy validation
- make health and smoke scripts check command exit codes instead of grepping output
- fail USB and binary-safety checks when commands or artifacts are unavailable
- add the missing smoke-test warning helper
- scope compliance wording checks to public UI code
- scope Pandora isolation checks to application and service boundaries
- strengthen Rust CI with formatting, warnings-as-errors Clippy, all-target builds, and all-target tests

### Rust and test repairs exposed by the stronger gate
- implement `Default` for `RoleManager`
- simplify USB string-descriptor error conversion
- rename the ambiguous device-mode parser
- remove a stale routing test import
- use idiomatic boolean assertions
- resolve jurisdiction data relative to its crate
- correct the court-order fixture without weakening the verification threshold

## Root cause

The existing shell checks inspected text output rather than Cargo exit status, allowing failed commands to appear successful. The compliance job scanned policy documents that intentionally define prohibited terminology. Once those gates were corrected, strict CI exposed several pre-existing lint and fixture defects.

## Validation

- Compliance Guard: passed
- `cargo fmt -- --check`: passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: passed
- `cargo build --workspace --all-targets`: passed
- `cargo test --workspace --all-targets`: passed
- workflow YAML parsing, shell syntax, and negative-path script behavior verified