### PR TITLE
Forensic USB R1: tamper-evident sessions and cross-platform release gates

### DIFF
--- a/.github/workflows/forensic-usb-core.yml
+++ b/.github/workflows/forensic-usb-core.yml
@@ -1,0 +1,59 @@
+name: Forensic USB Core
+
+on:
+  pull_request:
+    paths:
+      - 'libbootforge/**'
+      - '.github/workflows/forensic-usb-core.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'libbootforge/**'
+      - '.github/workflows/forensic-usb-core.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  core:
+    name: ${{ matrix.os }} / Rust ${{ matrix.rust }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        rust: [stable]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Format
+        run: cargo fmt --all --check
+      - name: Check library
+        run: cargo check -p libbootforge --all-targets
+      - name: Clippy
+        run: cargo clippy -p libbootforge --all-targets -- -D warnings
+      - name: Unit tests
+        run: cargo test -p libbootforge --all-targets
+
+  arcwyre-contract:
+    name: ARCWYRE feature contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check -p libbootforge --features arcwyre
+
+  docs:
+    name: Rustdoc warnings
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc -p libbootforge --no-deps

--- a/.github/workflows/rustfmt-autofix-r1.yml
+++ b/.github/workflows/rustfmt-autofix-r1.yml
@@ -1,0 +1,36 @@
+name: Rustfmt Autofix R1
+
+on:
+  push:
+    branches:
+      - feat/forensic-usb-max-output-r1
+
+permissions:
+  contents: write
+
+jobs:
+  format:
+    if: ${{ !contains(github.event.head_commit.message, '[skip rustfmt-autofix]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: feat/forensic-usb-max-output-r1
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Format workspace
+        run: cargo fmt --all
+      - name: Commit formatting when needed
+        shell: bash
+        run: |
+          if git diff --quiet; then
+            echo "No formatting changes required."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "style: apply workspace rustfmt [skip rustfmt-autofix]"
+          git push origin HEAD:feat/forensic-usb-max-output-r1

--- a/docs/FORENSIC_USB_VALIDATION_MATRIX.md
+++ b/docs/FORENSIC_USB_VALIDATION_MATRIX.md
@@ -1,0 +1,55 @@
+# BootForge USB Forensic Validation Matrix
+
+This document separates code presence from proof. A feature is not called hardware-validated merely because it compiled on a hosted runner, a surprisingly durable industry superstition.
+
+## Classification
+
+| Level | Meaning |
+|---|---|
+| Implemented | A code path exists with focused tests. |
+| Integrated | The path is connected to its caller and dependency chain. |
+| Emulator-validated | Reproduced under a named virtual or simulated configuration. |
+| Hardware-validated | Reproduced on identified physical hardware with retained evidence. |
+| Release candidate | All declared release gates pass; package is not yet published. |
+
+## Current matrix
+
+| Capability | Implemented | Integrated | CI target | Hardware evidence required |
+|---|---:|---:|---|---|
+| Cross-platform enumeration | Yes | Yes | Windows, Linux, macOS | At least two controllers per OS |
+| Stable identity | Yes | Yes | Deterministic unit tests | Same device across ports and reconnects |
+| Reconnect correlation | Yes | Yes | Synthetic snapshot tests | Serial and no-serial devices |
+| Protocol classification | Yes | Yes | Fixture tests | ADB, Fastboot, Apple Recovery, DFU, MTP/PTP, CDC |
+| Stateful health | Yes | Yes | Flap and transition tests | Controlled disconnect/reconnect campaign |
+| Linux driver reporting | Yes | Yes | Ubuntu | Bound and unbound devices |
+| Windows driver reporting | Yes | Yes | Windows | WinUSB, composite, missing/problem device |
+| macOS driver reporting | Contract only | Yes | macOS compile | IOKit implementation required |
+| ARCWYRE driver reporting | Contract only | Yes | Feature compile | Native backend implementation required |
+| Driver change events | Yes | Yes | Tracker tests | Driver state change campaign |
+| Notification wake contract | Yes | Yes | Concurrency tests | Windows callback implementation required |
+| Tamper-evident session recording | Yes | Yes | Cross-platform tests | Altered/reordered/truncated evidence files |
+
+## Pull request gates
+
+1. `cargo fmt --all --check`
+2. `cargo check -p libbootforge --all-targets`
+3. `cargo clippy -p libbootforge --all-targets -- -D warnings`
+4. `cargo test -p libbootforge --all-targets`
+5. `cargo check -p libbootforge --features arcwyre`
+6. `RUSTDOCFLAGS='-D warnings' cargo doc -p libbootforge --no-deps`
+7. Windows, Linux, and macOS matrix completion
+8. No destructive USB, driver, filesystem, or firmware operations introduced
+
+## Hardware receipt format
+
+Every hardware validation receipt must include:
+
+- date and operator
+- host OS and exact build
+- USB host controller and driver
+- device VID/PID, serial handling, and mode
+- hub/cable topology
+- command or test binary version
+- raw JSONL evidence file
+- final hash-chain verification result
+- pass/fail statement and observed limitations

--- a/libbootforge/examples/record_forensic_session.rs
+++ b/libbootforge/examples/record_forensic_session.rs
@@ -1,0 +1,21 @@
+use libbootforge::{ForensicEventMonitor, Result, SessionRecorder};
+use std::path::PathBuf;
+use std::time::Duration;
+
+fn main() -> Result<()> {
+    let output = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("bootforge-usb-session.jsonl"));
+
+    let mut watcher = ForensicEventMonitor::new()?;
+    let mut recorder = SessionRecorder::create(&output)?;
+
+    eprintln!("recording passive USB events to {}", output.display());
+    loop {
+        for event in watcher.wait_for_events(Duration::from_secs(1))? {
+            let envelope = recorder.append(event)?;
+            println!("{}", envelope.to_json_line()?);
+        }
+    }
+}

--- a/libbootforge/src/driver.rs
+++ b/libbootforge/src/driver.rs
@@ -120,7 +120,10 @@ impl DriverReport {
     }
 
     pub fn is_platform_enriched(&self) -> bool {
-        !matches!(self.backend, DriverBackend::LibusbFallback | DriverBackend::Unknown)
+        !matches!(
+            self.backend,
+            DriverBackend::LibusbFallback | DriverBackend::Unknown
+        )
     }
 }
 
@@ -170,13 +173,11 @@ impl DriverInspector for LinuxDriverInspector {
                 continue;
             }
 
-            let driver_name = fs::read_link(path.join("driver"))
-                .ok()
-                .and_then(|target| {
-                    target
-                        .file_name()
-                        .map(|name| name.to_string_lossy().into_owned())
-                });
+            let driver_name = fs::read_link(path.join("driver")).ok().and_then(|target| {
+                target
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+            });
             let bound = driver_name.is_some();
             let mut evidence = vec![DriverEvidence::BackendRecord, DriverEvidence::DeviceNode];
             if bound {

--- a/libbootforge/src/driver/windows.rs
+++ b/libbootforge/src/driver/windows.rs
@@ -8,7 +8,6 @@ use super::{
     WindowsDriverInspector,
 };
 use crate::types::DeviceInfo;
-use std::ffi::c_void;
 use std::mem::{size_of, zeroed};
 use std::ptr::{null, null_mut};
 

--- a/libbootforge/src/driver/windows.rs
+++ b/libbootforge/src/driver/windows.rs
@@ -73,8 +73,12 @@ extern "system" {
 
 #[link(name = "cfgmgr32")]
 extern "system" {
-    fn CM_Get_DevNode_Status(status: *mut u32, problem_number: *mut u32, dev_inst: u32, flags: u32)
-        -> u32;
+    fn CM_Get_DevNode_Status(
+        status: *mut u32,
+        problem_number: *mut u32,
+        dev_inst: u32,
+        flags: u32,
+    ) -> u32;
 }
 
 #[link(name = "kernel32")]
@@ -93,17 +97,15 @@ impl DriverInspector for WindowsDriverInspector {
 }
 
 unsafe fn inspect_present_device(device: &DeviceInfo) -> crate::Result<DriverReport> {
-    let set = SetupDiGetClassDevsW(
-        null(),
-        null(),
-        0,
-        DIGCF_PRESENT | DIGCF_ALLCLASSES,
-    );
+    let set = SetupDiGetClassDevsW(null(), null(), 0, DIGCF_PRESENT | DIGCF_ALLCLASSES);
 
     if set == INVALID_HANDLE_VALUE {
         return Ok(report_error(
             DriverState::PermissionDenied,
-            format!("SetupDiGetClassDevsW failed with Win32 error {}", GetLastError()),
+            format!(
+                "SetupDiGetClassDevsW failed with Win32 error {}",
+                GetLastError()
+            ),
         ));
     }
 
@@ -152,10 +154,7 @@ unsafe fn inspect_present_device(device: &DeviceInfo) -> crate::Result<DriverRep
         let mut problem = 0_u32;
         let cfg_result = CM_Get_DevNode_Status(&mut status, &mut problem, info.dev_inst, 0);
 
-        let mut evidence = vec![
-            DriverEvidence::BackendRecord,
-            DriverEvidence::DeviceNode,
-        ];
+        let mut evidence = vec![DriverEvidence::BackendRecord, DriverEvidence::DeviceNode];
         if service.is_some() {
             evidence.push(DriverEvidence::ServiceName);
             evidence.push(DriverEvidence::KernelBinding);
@@ -262,7 +261,10 @@ unsafe fn read_property_string(
 }
 
 fn wide_to_string(buffer: &[u16]) -> String {
-    let end = buffer.iter().position(|value| *value == 0).unwrap_or(buffer.len());
+    let end = buffer
+        .iter()
+        .position(|value| *value == 0)
+        .unwrap_or(buffer.len());
     String::from_utf16_lossy(&buffer[..end]).trim().to_string()
 }
 

--- a/libbootforge/src/driver_watch.rs
+++ b/libbootforge/src/driver_watch.rs
@@ -201,24 +201,38 @@ impl DriverChangeMonitor {
     }
 }
 
+#[cfg(windows)]
 fn native_source() -> ObservationSource {
-    #[cfg(windows)]
-    {
-        return ObservationSource::WindowsSetupApi;
-    }
-    #[cfg(target_os = "linux")]
-    {
-        return ObservationSource::LinuxSysfs;
-    }
-    #[cfg(target_os = "macos")]
-    {
-        return ObservationSource::MacOsIoKit;
-    }
-    #[cfg(feature = "arcwyre")]
-    {
-        return ObservationSource::ArcwyreNative;
-    }
-    #[allow(unreachable_code)]
+    ObservationSource::WindowsSetupApi
+}
+
+#[cfg(all(not(windows), target_os = "linux"))]
+fn native_source() -> ObservationSource {
+    ObservationSource::LinuxSysfs
+}
+
+#[cfg(all(not(windows), not(target_os = "linux"), target_os = "macos"))]
+fn native_source() -> ObservationSource {
+    ObservationSource::MacOsIoKit
+}
+
+#[cfg(all(
+    not(windows),
+    not(target_os = "linux"),
+    not(target_os = "macos"),
+    feature = "arcwyre"
+))]
+fn native_source() -> ObservationSource {
+    ObservationSource::ArcwyreNative
+}
+
+#[cfg(all(
+    not(windows),
+    not(target_os = "linux"),
+    not(target_os = "macos"),
+    not(feature = "arcwyre")
+))]
+fn native_source() -> ObservationSource {
     ObservationSource::Unknown
 }
 

--- a/libbootforge/src/driver_watch.rs
+++ b/libbootforge/src/driver_watch.rs
@@ -38,17 +38,39 @@ pub struct DriverChange {
 impl DriverChange {
     pub fn between(previous: &DriverReport, current: &DriverReport) -> Self {
         let mut fields = Vec::new();
-        if previous.backend != current.backend { fields.push(DriverChangeField::Backend); }
-        if previous.state != current.state { fields.push(DriverChangeField::State); }
-        if previous.confidence != current.confidence { fields.push(DriverChangeField::Confidence); }
-        if previous.driver_name != current.driver_name { fields.push(DriverChangeField::DriverName); }
-        if previous.service_name != current.service_name { fields.push(DriverChangeField::ServiceName); }
-        if previous.provider != current.provider { fields.push(DriverChangeField::Provider); }
-        if previous.version != current.version { fields.push(DriverChangeField::Version); }
-        if previous.signed != current.signed { fields.push(DriverChangeField::SignatureState); }
-        if previous.problem_code != current.problem_code { fields.push(DriverChangeField::ProblemCode); }
-        if previous.device_node != current.device_node { fields.push(DriverChangeField::DeviceNode); }
-        if previous.evidence != current.evidence { fields.push(DriverChangeField::Evidence); }
+        if previous.backend != current.backend {
+            fields.push(DriverChangeField::Backend);
+        }
+        if previous.state != current.state {
+            fields.push(DriverChangeField::State);
+        }
+        if previous.confidence != current.confidence {
+            fields.push(DriverChangeField::Confidence);
+        }
+        if previous.driver_name != current.driver_name {
+            fields.push(DriverChangeField::DriverName);
+        }
+        if previous.service_name != current.service_name {
+            fields.push(DriverChangeField::ServiceName);
+        }
+        if previous.provider != current.provider {
+            fields.push(DriverChangeField::Provider);
+        }
+        if previous.version != current.version {
+            fields.push(DriverChangeField::Version);
+        }
+        if previous.signed != current.signed {
+            fields.push(DriverChangeField::SignatureState);
+        }
+        if previous.problem_code != current.problem_code {
+            fields.push(DriverChangeField::ProblemCode);
+        }
+        if previous.device_node != current.device_node {
+            fields.push(DriverChangeField::DeviceNode);
+        }
+        if previous.evidence != current.evidence {
+            fields.push(DriverChangeField::Evidence);
+        }
         Self {
             changed: !fields.is_empty(),
             fields,
@@ -68,7 +90,11 @@ impl DriverStateTracker {
         self.reports.insert(device_id.into(), report);
     }
 
-    pub fn observe(&mut self, device_id: impl Into<String>, report: DriverReport) -> Option<DriverChange> {
+    pub fn observe(
+        &mut self,
+        device_id: impl Into<String>,
+        report: DriverReport,
+    ) -> Option<DriverChange> {
         let device_id = device_id.into();
         let change = self
             .reports
@@ -88,7 +114,9 @@ impl DriverStateTracker {
     }
 
     pub fn merge_identity(&mut self, previous_id: &str, current_id: &str) {
-        if previous_id == current_id { return; }
+        if previous_id == current_id {
+            return;
+        }
         if let Some(report) = self.reports.remove(previous_id) {
             self.reports.entry(current_id.to_string()).or_insert(report);
         }
@@ -164,20 +192,32 @@ impl DriverChangeMonitor {
         }
     }
 
-    pub fn sequence(&self) -> u64 { self.sequence }
+    pub fn sequence(&self) -> u64 {
+        self.sequence
+    }
 
-    pub fn last_wake(&self) -> Option<WakeResult> { self.last_wake }
+    pub fn last_wake(&self) -> Option<WakeResult> {
+        self.last_wake
+    }
 }
 
 fn native_source() -> ObservationSource {
     #[cfg(windows)]
-    { return ObservationSource::WindowsSetupApi; }
+    {
+        return ObservationSource::WindowsSetupApi;
+    }
     #[cfg(target_os = "linux")]
-    { return ObservationSource::LinuxSysfs; }
+    {
+        return ObservationSource::LinuxSysfs;
+    }
     #[cfg(target_os = "macos")]
-    { return ObservationSource::MacOsIoKit; }
+    {
+        return ObservationSource::MacOsIoKit;
+    }
     #[cfg(feature = "arcwyre")]
-    { return ObservationSource::ArcwyreNative; }
+    {
+        return ObservationSource::ArcwyreNative;
+    }
     #[allow(unreachable_code)]
     ObservationSource::Unknown
 }

--- a/libbootforge/src/error.rs
+++ b/libbootforge/src/error.rs
@@ -1,8 +1,8 @@
-//! Error types for libbootforge
+//! Error types for libbootforge.
 
 use thiserror::Error;
 
-/// Central error enum for all bootforge operations
+/// Central error enum for all BootForge USB operations.
 #[derive(Error, Debug)]
 pub enum BootforgeError {
     #[error("USB subsystem unavailable")]
@@ -11,19 +11,22 @@ pub enum BootforgeError {
     #[error("USB scan failed: {0}")]
     UsbScanFailed(String),
 
-    #[error("Failed to read descriptor: {0}")]
+    #[error("failed to read descriptor: {0}")]
     DescriptorReadFailed(String),
 
-    #[error("Failed to open device: {0}")]
+    #[error("failed to open device: {0}")]
     DeviceOpenFailed(String),
 
     #[error("JSON serialization failed: {0}")]
     JsonSerializationFailed(String),
 
+    #[error("evidence chain invalid: {0}")]
+    EvidenceChainInvalid(String),
+
     #[error("USB error: {0}")]
     UsbError(#[from] rusb::Error),
 
-    #[error("IO error: {0}")]
+    #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
 }
 

--- a/libbootforge/src/events.rs
+++ b/libbootforge/src/events.rs
@@ -148,7 +148,9 @@ impl ForensicEventMonitor {
 
         for removed_id in previous_ids.difference(&current_ids) {
             if let Some(previous) = self.known_devices.get(removed_id).cloned() {
-                let report = self.health_tracker.record_disconnect(removed_id, Utc::now());
+                let report = self
+                    .health_tracker
+                    .record_disconnect(removed_id, Utc::now());
                 events.push(self.event_with_health(
                     ForensicEventKind::DeviceDisconnected,
                     &previous,
@@ -163,8 +165,7 @@ impl ForensicEventMonitor {
         for (stable_id, device) in &current_map {
             if let Some(previous) = self.known_devices.get(stable_id).cloned() {
                 if previous.mode != device.mode {
-                    self.health_tracker
-                        .record_enumeration_success(stable_id);
+                    self.health_tracker.record_enumeration_success(stable_id);
                     let report = self.health_tracker.record_mode_transition(stable_id);
                     let message =
                         format!("mode changed from {:?} to {:?}", previous.mode, device.mode);
@@ -175,9 +176,7 @@ impl ForensicEventMonitor {
                         report,
                     ));
                 } else if previous != *device {
-                    let report = self
-                        .health_tracker
-                        .record_enumeration_success(stable_id);
+                    let report = self.health_tracker.record_enumeration_success(stable_id);
                     events.push(self.event_with_health(
                         ForensicEventKind::DeviceChanged,
                         device,
@@ -198,10 +197,8 @@ impl ForensicEventMonitor {
 
             if let Some((index, matched)) = reconnect {
                 let (previous_id, previous) = self.recently_disconnected.remove(index);
-                self.health_tracker
-                    .merge_identity(&previous_id, stable_id);
-                self.health_tracker
-                    .record_enumeration_success(stable_id);
+                self.health_tracker.merge_identity(&previous_id, stable_id);
+                self.health_tracker.record_enumeration_success(stable_id);
                 let report = self.health_tracker.record_reconnect(stable_id, Utc::now());
                 let message = format!(
                     "reconnect correlated with score {} and {:?} confidence; previous bus/address {}:{}",
@@ -217,9 +214,7 @@ impl ForensicEventMonitor {
                     report,
                 ));
             } else {
-                let report = self
-                    .health_tracker
-                    .record_enumeration_success(stable_id);
+                let report = self.health_tracker.record_enumeration_success(stable_id);
                 events.push(self.event_with_health(
                     ForensicEventKind::DeviceConnected,
                     device,
@@ -265,14 +260,8 @@ impl ForensicEventMonitor {
         report: HealthReport,
     ) -> ForensicEvent {
         self.sequence = self.sequence.saturating_add(1);
-        ForensicEvent::from_device(
-            self.sequence,
-            kind,
-            self.source.clone(),
-            device,
-            message,
-        )
-        .with_health_report(report)
+        ForensicEvent::from_device(self.sequence, kind, self.source.clone(), device, message)
+            .with_health_report(report)
     }
 }
 
@@ -318,20 +307,14 @@ mod tests {
     fn disconnect_and_reconnect_carry_accumulated_health() {
         let original = device("SERIAL-1", 2, DeviceMode::Adb);
         let stable_id = DeviceIdentity::from_device(&original).stable_id;
-        let mut monitor = ForensicEventMonitor::from_snapshot(
-            ObservationSource::Libusb,
-            vec![original],
-        );
+        let mut monitor =
+            ForensicEventMonitor::from_snapshot(ObservationSource::Libusb, vec![original]);
 
         let removed = monitor.process_snapshot(Vec::new());
         assert_eq!(removed[0].kind, ForensicEventKind::DeviceDisconnected);
         assert_eq!(removed[0].health_report.disconnect_count, 1);
 
-        let reconnected = monitor.process_snapshot(vec![device(
-            "SERIAL-1",
-            9,
-            DeviceMode::Adb,
-        )]);
+        let reconnected = monitor.process_snapshot(vec![device("SERIAL-1", 9, DeviceMode::Adb)]);
         assert_eq!(reconnected[0].kind, ForensicEventKind::DeviceReconnected);
         assert_eq!(reconnected[0].health_report.reconnect_count, 1);
         assert_eq!(reconnected[0].health_report.rapid_reconnect_count, 1);
@@ -339,19 +322,19 @@ mod tests {
             .health_report
             .signals
             .contains(&HealthSignal::RapidReconnect));
-        assert_ne!(monitor.health_report(&stable_id).state, HealthState::Unknown);
+        assert_ne!(
+            monitor.health_report(&stable_id).state,
+            HealthState::Unknown
+        );
     }
 
     #[test]
     fn mode_change_updates_health_history() {
         let original = device("SERIAL-2", 2, DeviceMode::Adb);
-        let mut monitor = ForensicEventMonitor::from_snapshot(
-            ObservationSource::Libusb,
-            vec![original],
-        );
+        let mut monitor =
+            ForensicEventMonitor::from_snapshot(ObservationSource::Libusb, vec![original]);
 
-        let events =
-            monitor.process_snapshot(vec![device("SERIAL-2", 2, DeviceMode::Fastboot)]);
+        let events = monitor.process_snapshot(vec![device("SERIAL-2", 2, DeviceMode::Fastboot)]);
         assert_eq!(events[0].kind, ForensicEventKind::ModeChanged);
         assert_eq!(events[0].health_report.mode_transition_count, 1);
         assert!(events[0]
@@ -365,8 +348,7 @@ mod tests {
         let mut monitor =
             ForensicEventMonitor::from_snapshot(ObservationSource::Libusb, Vec::new());
 
-        let events =
-            monitor.process_snapshot(vec![device("SERIAL-3", 4, DeviceMode::Adb)]);
+        let events = monitor.process_snapshot(vec![device("SERIAL-3", 4, DeviceMode::Adb)]);
         assert_eq!(events[0].kind, ForensicEventKind::DeviceConnected);
         assert_eq!(events[0].health_report.state, HealthState::Healthy);
         assert_eq!(events[0].health_report.enumeration_success_count, 1);

--- a/libbootforge/src/health.rs
+++ b/libbootforge/src/health.rs
@@ -41,14 +41,7 @@ pub struct HealthReport {
 impl HealthReport {
     /// Compatibility constructor retained for existing consumers.
     pub fn from_counts(disconnect_count: u32, reconnect_count: u32, rapid_reconnects: u32) -> Self {
-        Self::from_evidence(
-            1,
-            0,
-            disconnect_count,
-            reconnect_count,
-            rapid_reconnects,
-            0,
-        )
+        Self::from_evidence(1, 0, disconnect_count, reconnect_count, rapid_reconnects, 0)
     }
 
     /// Build a report only from observable counters.
@@ -210,14 +203,22 @@ impl HealthTracker {
         history.report()
     }
 
-    pub fn record_disconnect(&mut self, device_id: &str, observed_at: DateTime<Utc>) -> HealthReport {
+    pub fn record_disconnect(
+        &mut self,
+        device_id: &str,
+        observed_at: DateTime<Utc>,
+    ) -> HealthReport {
         let history = self.histories.entry(device_id.to_owned()).or_default();
         history.disconnect_count = history.disconnect_count.saturating_add(1);
         history.last_disconnect_at = Some(observed_at);
         history.report()
     }
 
-    pub fn record_reconnect(&mut self, device_id: &str, observed_at: DateTime<Utc>) -> HealthReport {
+    pub fn record_reconnect(
+        &mut self,
+        device_id: &str,
+        observed_at: DateTime<Utc>,
+    ) -> HealthReport {
         let history = self.histories.entry(device_id.to_owned()).or_default();
         history.reconnect_count = history.reconnect_count.saturating_add(1);
         if let Some(disconnected_at) = history.last_disconnect_at {

--- a/libbootforge/src/identity.rs
+++ b/libbootforge/src/identity.rs
@@ -93,7 +93,11 @@ impl DeviceIdentity {
             IdentityConfidence::Low
         };
 
-        Self { stable_id, confidence, evidence }
+        Self {
+            stable_id,
+            confidence,
+            evidence,
+        }
     }
 }
 

--- a/libbootforge/src/lib.rs
+++ b/libbootforge/src/lib.rs
@@ -13,10 +13,10 @@ pub mod identity;
 pub mod native_driver;
 pub mod notification;
 pub mod protocol;
+pub mod recorder;
 pub mod session;
 pub mod types;
 
-// Backward-compatible modules.
 pub mod descriptors;
 pub mod device;
 pub mod enumeration;
@@ -45,17 +45,19 @@ pub use notification::{
 pub use protocol::{
     ProtocolConfidence, ProtocolEvidence, ProtocolObservation, ProtocolReport, UsbProtocol,
 };
+pub use recorder::{
+    verify_session, EvidenceEnvelope, SessionRecorder, VerificationReport,
+    RECORD_SCHEMA_VERSION,
+};
 pub use types::{
     DeviceFamily, DeviceFingerprint, DeviceInfo, DeviceMode, DevicePlatform, DeviceTransport,
     FingerprintConfidence, WorkflowRecommendation,
 };
 
-// Legacy exports retained for existing consumers.
 pub use descriptors::DeviceDescriptor;
 pub use enumeration::enumerate_devices;
 pub use events::DeviceEventMonitor;
 
-/// Scan devices and return a deterministic pretty-printed JSON document.
 pub fn scan_devices_json() -> Result<String> {
     let devices = scan_devices()?;
     serde_json::to_string_pretty(&devices)
@@ -82,6 +84,8 @@ mod tests {
         let _health: Option<HealthReport> = None;
         let _health_tracker: Option<HealthTracker> = None;
         let _watcher: Option<ForensicEventMonitor> = None;
+        let _envelope: Option<EvidenceEnvelope> = None;
+        let _verification: Option<VerificationReport> = None;
         let _router: fn(&DeviceInfo) -> DriverReport = inspect_platform_driver;
     }
 }

--- a/libbootforge/src/lib.rs
+++ b/libbootforge/src/lib.rs
@@ -25,12 +25,9 @@ pub mod events;
 pub use detect::scanner::scan_devices;
 pub use driver::{
     ArcwyreDriverInspector, DriverBackend, DriverConfidence, DriverEvidence, DriverInspector,
-    DriverReport, DriverState, LinuxDriverInspector, MacOsDriverInspector,
-    WindowsDriverInspector,
+    DriverReport, DriverState, LinuxDriverInspector, MacOsDriverInspector, WindowsDriverInspector,
 };
-pub use driver_watch::{
-    DriverChange, DriverChangeField, DriverChangeMonitor, DriverStateTracker,
-};
+pub use driver_watch::{DriverChange, DriverChangeField, DriverChangeMonitor, DriverStateTracker};
 pub use error::{BootforgeError, Result};
 pub use events::ForensicEventMonitor;
 pub use forensic::{ForensicEvent, ForensicEventKind, ObservationSource};
@@ -39,15 +36,12 @@ pub use identity::{
     correlate_reconnect, DeviceIdentity, IdentityConfidence, IdentityEvidence, ReconnectMatch,
 };
 pub use native_driver::inspect_platform_driver;
-pub use notification::{
-    NotificationSignal, NotificationWake, PollingWake, WakeReason, WakeResult,
-};
+pub use notification::{NotificationSignal, NotificationWake, PollingWake, WakeReason, WakeResult};
 pub use protocol::{
     ProtocolConfidence, ProtocolEvidence, ProtocolObservation, ProtocolReport, UsbProtocol,
 };
 pub use recorder::{
-    verify_session, EvidenceEnvelope, SessionRecorder, VerificationReport,
-    RECORD_SCHEMA_VERSION,
+    verify_session, EvidenceEnvelope, SessionRecorder, VerificationReport, RECORD_SCHEMA_VERSION,
 };
 pub use types::{
     DeviceFamily, DeviceFingerprint, DeviceInfo, DeviceMode, DevicePlatform, DeviceTransport,

--- a/libbootforge/src/native_driver.rs
+++ b/libbootforge/src/native_driver.rs
@@ -10,7 +10,10 @@ pub fn inspect_platform_driver(device: &DeviceInfo) -> DriverReport {
     inspect_native(device).unwrap_or_else(|_| DriverReport::passive_fallback(device))
 }
 
-#[cfg(all(feature = "arcwyre", not(any(windows, target_os = "linux", target_os = "macos"))))]
+#[cfg(all(
+    feature = "arcwyre",
+    not(any(windows, target_os = "linux", target_os = "macos"))
+))]
 fn inspect_native(device: &DeviceInfo) -> crate::Result<DriverReport> {
     use crate::driver::{ArcwyreDriverInspector, DriverInspector};
     ArcwyreDriverInspector.inspect(device)

--- a/libbootforge/src/protocol.rs
+++ b/libbootforge/src/protocol.rs
@@ -52,26 +52,65 @@ impl ProtocolReport {
     pub fn from_device(device: &DeviceInfo) -> Self {
         let mut observations = Vec::new();
         let mut add = |protocol, confidence, evidence| {
-            if !observations.iter().any(|item: &ProtocolObservation| item.protocol == protocol) {
-                observations.push(ProtocolObservation { protocol, confidence, evidence });
+            if !observations
+                .iter()
+                .any(|item: &ProtocolObservation| item.protocol == protocol)
+            {
+                observations.push(ProtocolObservation {
+                    protocol,
+                    confidence,
+                    evidence,
+                });
             }
         };
 
         match device.mode {
-            DeviceMode::Adb => add(UsbProtocol::Adb, ProtocolConfidence::High, vec![ProtocolEvidence::DeviceMode]),
-            DeviceMode::Fastboot | DeviceMode::Bootloader => add(UsbProtocol::Fastboot, ProtocolConfidence::High, vec![ProtocolEvidence::DeviceMode]),
-            DeviceMode::Dfu => add(UsbProtocol::Dfu, ProtocolConfidence::High, vec![ProtocolEvidence::DeviceMode]),
-            DeviceMode::Recovery if device.platform == DevicePlatform::Apple => add(UsbProtocol::AppleRecovery, ProtocolConfidence::High, vec![ProtocolEvidence::DeviceMode, ProtocolEvidence::Platform]),
-            DeviceMode::MassStorage => add(UsbProtocol::MassStorage, ProtocolConfidence::High, vec![ProtocolEvidence::DeviceMode]),
+            DeviceMode::Adb => add(
+                UsbProtocol::Adb,
+                ProtocolConfidence::High,
+                vec![ProtocolEvidence::DeviceMode],
+            ),
+            DeviceMode::Fastboot | DeviceMode::Bootloader => add(
+                UsbProtocol::Fastboot,
+                ProtocolConfidence::High,
+                vec![ProtocolEvidence::DeviceMode],
+            ),
+            DeviceMode::Dfu => add(
+                UsbProtocol::Dfu,
+                ProtocolConfidence::High,
+                vec![ProtocolEvidence::DeviceMode],
+            ),
+            DeviceMode::Recovery if device.platform == DevicePlatform::Apple => add(
+                UsbProtocol::AppleRecovery,
+                ProtocolConfidence::High,
+                vec![ProtocolEvidence::DeviceMode, ProtocolEvidence::Platform],
+            ),
+            DeviceMode::MassStorage => add(
+                UsbProtocol::MassStorage,
+                ProtocolConfidence::High,
+                vec![ProtocolEvidence::DeviceMode],
+            ),
             _ => {}
         }
 
         if device.platform == DevicePlatform::Apple && matches!(device.mode, DeviceMode::Normal) {
-            add(UsbProtocol::AppleMobile, ProtocolConfidence::Medium, vec![ProtocolEvidence::Platform, ProtocolEvidence::VendorProduct]);
+            add(
+                UsbProtocol::AppleMobile,
+                ProtocolConfidence::Medium,
+                vec![ProtocolEvidence::Platform, ProtocolEvidence::VendorProduct],
+            );
         }
 
-        let product = device.product_name.as_deref().unwrap_or_default().to_ascii_lowercase();
-        let profile = device.matched_profile.as_deref().unwrap_or_default().to_ascii_lowercase();
+        let product = device
+            .product_name
+            .as_deref()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let profile = device
+            .matched_profile
+            .as_deref()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
         for (needle, protocol) in [
             ("mtp", UsbProtocol::Mtp),
             ("ptp", UsbProtocol::Ptp),
@@ -81,7 +120,14 @@ impl ProtocolReport {
             ("dfu", UsbProtocol::Dfu),
         ] {
             if product.contains(needle) || profile.contains(needle) {
-                add(protocol, ProtocolConfidence::Medium, vec![ProtocolEvidence::ProductString, ProtocolEvidence::MatchedProfile]);
+                add(
+                    protocol,
+                    ProtocolConfidence::Medium,
+                    vec![
+                        ProtocolEvidence::ProductString,
+                        ProtocolEvidence::MatchedProfile,
+                    ],
+                );
             }
         }
 
@@ -93,21 +139,39 @@ impl ProtocolReport {
             });
         }
 
-        Self { observations, active_probe_performed: false }
+        Self {
+            observations,
+            active_probe_performed: false,
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{DeviceFamily, DeviceFingerprint, DeviceTransport, FingerprintConfidence, WorkflowRecommendation};
+    use crate::types::{
+        DeviceFamily, DeviceFingerprint, DeviceTransport, FingerprintConfidence,
+        WorkflowRecommendation,
+    };
 
     fn fixture(mode: DeviceMode, platform: DevicePlatform) -> DeviceInfo {
         DeviceInfo {
-            bus_number: 1, address: 2, vendor_id: 0x18d1, product_id: 0x4ee1,
-            vendor_name: None, manufacturer: None, product_name: Some("Android ADB".into()),
-            serial_number: Some("S1".into()), platform, transport: DeviceTransport::Usb2, mode,
-            fingerprint: DeviceFingerprint { family: DeviceFamily::AndroidPhone, model_hint: None, confidence: FingerprintConfidence::High },
+            bus_number: 1,
+            address: 2,
+            vendor_id: 0x18d1,
+            product_id: 0x4ee1,
+            vendor_name: None,
+            manufacturer: None,
+            product_name: Some("Android ADB".into()),
+            serial_number: Some("S1".into()),
+            platform,
+            transport: DeviceTransport::Usb2,
+            mode,
+            fingerprint: DeviceFingerprint {
+                family: DeviceFamily::AndroidPhone,
+                model_hint: None,
+                confidence: FingerprintConfidence::High,
+            },
             recommended_workflow: WorkflowRecommendation::AndroidAdbWorkflow,
             matched_profile: Some("android-adb".into()),
         }
@@ -115,8 +179,12 @@ mod tests {
 
     #[test]
     fn adb_is_classified_without_active_probe() {
-        let report = ProtocolReport::from_device(&fixture(DeviceMode::Adb, DevicePlatform::Android));
-        assert!(report.observations.iter().any(|item| item.protocol == UsbProtocol::Adb));
+        let report =
+            ProtocolReport::from_device(&fixture(DeviceMode::Adb, DevicePlatform::Android));
+        assert!(report
+            .observations
+            .iter()
+            .any(|item| item.protocol == UsbProtocol::Adb));
         assert!(!report.active_probe_performed);
     }
 }

--- a/libbootforge/src/recorder.rs
+++ b/libbootforge/src/recorder.rs
@@ -1,15 +1,11 @@
 //! Tamper-evident append-only forensic session recording.
-//!
-//! Each JSONL envelope contains one normalized forensic event and a SHA-256 chain link.
-//! The recorder never modifies prior records. Verification recomputes every link and rejects
-//! missing, reordered, or altered lines.
 
 use crate::{BootforgeError, ForensicEvent, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs::{File, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Error, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 pub const RECORD_SCHEMA_VERSION: u16 = 1;
@@ -29,25 +25,19 @@ impl EvidenceEnvelope {
         previous_hash: Option<&str>,
         event: &ForensicEvent,
     ) -> Result<String> {
-        serde_json::to_string(&(
-            RECORD_SCHEMA_VERSION,
-            recorded_at,
-            previous_hash,
-            event,
-        ))
-        .map_err(|error| BootforgeError::JsonSerializationFailed(error.to_string()))
+        serde_json::to_string(&(RECORD_SCHEMA_VERSION, recorded_at, previous_hash, event))
+            .map_err(|error| BootforgeError::JsonSerializationFailed(error.to_string()))
     }
 
     pub fn create(previous_hash: Option<String>, event: ForensicEvent) -> Result<Self> {
         let recorded_at = Utc::now();
         let payload = Self::unsigned_payload(recorded_at, previous_hash.as_deref(), &event)?;
-        let current_hash = sha256_hex(payload.as_bytes());
         Ok(Self {
             schema_version: RECORD_SCHEMA_VERSION,
             recorded_at,
             previous_hash,
             event,
-            current_hash,
+            current_hash: sha256_hex(payload.as_bytes()),
         })
     }
 
@@ -86,8 +76,7 @@ impl SessionRecorder {
             .create(true)
             .truncate(true)
             .write(true)
-            .open(&path)
-            .map_err(|error| BootforgeError::Io(error.to_string()))?;
+            .open(&path)?;
         Ok(Self {
             path,
             file,
@@ -100,16 +89,15 @@ impl SessionRecorder {
         let path = path.as_ref().to_path_buf();
         let verification = verify_session(&path)?;
         if !verification.valid {
-            return Err(BootforgeError::Io(format!(
-                "refusing to resume invalid evidence chain at record {:?}",
-                verification.first_invalid_record
+            return Err(BootforgeError::IoError(Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "refusing to resume invalid evidence chain at record {:?}",
+                    verification.first_invalid_record
+                ),
             )));
         }
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .map_err(|error| BootforgeError::Io(error.to_string()))?;
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
         Ok(Self {
             path,
             file,
@@ -120,11 +108,8 @@ impl SessionRecorder {
 
     pub fn append(&mut self, event: ForensicEvent) -> Result<EvidenceEnvelope> {
         let envelope = EvidenceEnvelope::create(self.last_hash.clone(), event)?;
-        writeln!(self.file, "{}", envelope.to_json_line()?)
-            .map_err(|error| BootforgeError::Io(error.to_string()))?;
-        self.file
-            .flush()
-            .map_err(|error| BootforgeError::Io(error.to_string()))?;
+        writeln!(self.file, "{}", envelope.to_json_line()?)?;
+        self.file.flush()?;
         self.last_hash = Some(envelope.current_hash.clone());
         self.records_written = self.records_written.saturating_add(1);
         Ok(envelope)
@@ -162,12 +147,12 @@ pub fn verify_session(path: impl AsRef<Path>) -> Result<VerificationReport> {
         });
     }
 
-    let file = File::open(path).map_err(|error| BootforgeError::Io(error.to_string()))?;
+    let file = File::open(path)?;
     let mut previous_hash: Option<String> = None;
     let mut records = 0_u64;
 
     for line in BufReader::new(file).lines() {
-        let line = line.map_err(|error| BootforgeError::Io(error.to_string()))?;
+        let line = line?;
         if line.trim().is_empty() {
             continue;
         }

--- a/libbootforge/src/recorder.rs
+++ b/libbootforge/src/recorder.rs
@@ -47,11 +47,8 @@ impl EvidenceEnvelope {
         {
             return Ok(false);
         }
-        let payload = Self::unsigned_payload(
-            self.recorded_at,
-            self.previous_hash.as_deref(),
-            &self.event,
-        )?;
+        let payload =
+            Self::unsigned_payload(self.recorded_at, self.previous_hash.as_deref(), &self.event)?;
         Ok(self.current_hash == sha256_hex(payload.as_bytes()))
     }
 

--- a/libbootforge/src/recorder.rs
+++ b/libbootforge/src/recorder.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs::{File, OpenOptions};
-use std::io::{BufRead, BufReader, Error, ErrorKind, Write};
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 
 pub const RECORD_SCHEMA_VERSION: u16 = 1;
@@ -86,12 +86,9 @@ impl SessionRecorder {
         let path = path.as_ref().to_path_buf();
         let verification = verify_session(&path)?;
         if !verification.valid {
-            return Err(BootforgeError::IoError(Error::new(
-                ErrorKind::InvalidData,
-                format!(
-                    "refusing to resume invalid evidence chain at record {:?}",
-                    verification.first_invalid_record
-                ),
+            return Err(BootforgeError::EvidenceChainInvalid(format!(
+                "refusing to resume invalid evidence chain at record {:?}",
+                verification.first_invalid_record
             )));
         }
         let file = OpenOptions::new().create(true).append(true).open(&path)?;
@@ -179,4 +176,93 @@ fn sha256_hex(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
     format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        DeviceFamily, DeviceFingerprint, DeviceInfo, DeviceMode, DevicePlatform, DeviceTransport,
+        FingerprintConfidence, ForensicEventKind, ObservationSource, WorkflowRecommendation,
+    };
+    use std::fs;
+
+    fn event(sequence: u64) -> ForensicEvent {
+        let device = DeviceInfo {
+            bus_number: 1,
+            address: 2,
+            vendor_id: 0x18d1,
+            product_id: 0x4ee1,
+            vendor_name: Some("Google".into()),
+            manufacturer: Some("Google".into()),
+            product_name: Some("Android ADB".into()),
+            serial_number: Some("RECORDER-TEST".into()),
+            platform: DevicePlatform::Android,
+            transport: DeviceTransport::Usb2,
+            mode: DeviceMode::Adb,
+            fingerprint: DeviceFingerprint {
+                family: DeviceFamily::AndroidPhone,
+                model_hint: None,
+                confidence: FingerprintConfidence::High,
+            },
+            recommended_workflow: WorkflowRecommendation::AndroidAdbWorkflow,
+            matched_profile: Some("android-adb".into()),
+        };
+        ForensicEvent::from_device(
+            sequence,
+            ForensicEventKind::DeviceObserved,
+            ObservationSource::Libusb,
+            &device,
+            None,
+        )
+    }
+
+    fn temp_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "bootforge-{name}-{}-{}.jsonl",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ))
+    }
+
+    #[test]
+    fn valid_chain_verifies_and_resumes() {
+        let path = temp_path("valid-chain");
+        {
+            let mut recorder = SessionRecorder::create(&path).expect("create recorder");
+            recorder.append(event(1)).expect("append first event");
+            recorder.append(event(2)).expect("append second event");
+        }
+
+        let report = verify_session(&path).expect("verify chain");
+        assert!(report.valid);
+        assert_eq!(report.records, 2);
+
+        let recorder = SessionRecorder::resume(&path).expect("resume valid chain");
+        assert_eq!(recorder.records_written(), 2);
+        assert_eq!(recorder.last_hash(), report.last_hash.as_deref());
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn tampered_record_is_rejected() {
+        let path = temp_path("tampered-chain");
+        {
+            let mut recorder = SessionRecorder::create(&path).expect("create recorder");
+            recorder.append(event(1)).expect("append event");
+        }
+
+        let contents = fs::read_to_string(&path).expect("read evidence");
+        fs::write(&path, contents.replace("DeviceObserved", "DeviceConnected"))
+            .expect("tamper evidence");
+
+        let report = verify_session(&path).expect("verify tampered chain");
+        assert!(!report.valid);
+        assert_eq!(report.first_invalid_record, Some(1));
+        assert!(matches!(
+            SessionRecorder::resume(&path),
+            Err(BootforgeError::EvidenceChainInvalid(_))
+        ));
+        let _ = fs::remove_file(path);
+    }
 }

--- a/libbootforge/src/recorder.rs
+++ b/libbootforge/src/recorder.rs
@@ -1,0 +1,200 @@
+//! Tamper-evident append-only forensic session recording.
+//!
+//! Each JSONL envelope contains one normalized forensic event and a SHA-256 chain link.
+//! The recorder never modifies prior records. Verification recomputes every link and rejects
+//! missing, reordered, or altered lines.
+
+use crate::{BootforgeError, ForensicEvent, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+pub const RECORD_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EvidenceEnvelope {
+    pub schema_version: u16,
+    pub recorded_at: DateTime<Utc>,
+    pub previous_hash: Option<String>,
+    pub event: ForensicEvent,
+    pub current_hash: String,
+}
+
+impl EvidenceEnvelope {
+    fn unsigned_payload(
+        recorded_at: DateTime<Utc>,
+        previous_hash: Option<&str>,
+        event: &ForensicEvent,
+    ) -> Result<String> {
+        serde_json::to_string(&(
+            RECORD_SCHEMA_VERSION,
+            recorded_at,
+            previous_hash,
+            event,
+        ))
+        .map_err(|error| BootforgeError::JsonSerializationFailed(error.to_string()))
+    }
+
+    pub fn create(previous_hash: Option<String>, event: ForensicEvent) -> Result<Self> {
+        let recorded_at = Utc::now();
+        let payload = Self::unsigned_payload(recorded_at, previous_hash.as_deref(), &event)?;
+        let current_hash = sha256_hex(payload.as_bytes());
+        Ok(Self {
+            schema_version: RECORD_SCHEMA_VERSION,
+            recorded_at,
+            previous_hash,
+            event,
+            current_hash,
+        })
+    }
+
+    pub fn verify(&self, expected_previous_hash: Option<&str>) -> Result<bool> {
+        if self.schema_version != RECORD_SCHEMA_VERSION
+            || self.previous_hash.as_deref() != expected_previous_hash
+        {
+            return Ok(false);
+        }
+        let payload = Self::unsigned_payload(
+            self.recorded_at,
+            self.previous_hash.as_deref(),
+            &self.event,
+        )?;
+        Ok(self.current_hash == sha256_hex(payload.as_bytes()))
+    }
+
+    pub fn to_json_line(&self) -> Result<String> {
+        serde_json::to_string(self)
+            .map_err(|error| BootforgeError::JsonSerializationFailed(error.to_string()))
+    }
+}
+
+#[derive(Debug)]
+pub struct SessionRecorder {
+    path: PathBuf,
+    file: File,
+    last_hash: Option<String>,
+    records_written: u64,
+}
+
+impl SessionRecorder {
+    pub fn create(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&path)
+            .map_err(|error| BootforgeError::Io(error.to_string()))?;
+        Ok(Self {
+            path,
+            file,
+            last_hash: None,
+            records_written: 0,
+        })
+    }
+
+    pub fn resume(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        let verification = verify_session(&path)?;
+        if !verification.valid {
+            return Err(BootforgeError::Io(format!(
+                "refusing to resume invalid evidence chain at record {:?}",
+                verification.first_invalid_record
+            )));
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|error| BootforgeError::Io(error.to_string()))?;
+        Ok(Self {
+            path,
+            file,
+            last_hash: verification.last_hash,
+            records_written: verification.records,
+        })
+    }
+
+    pub fn append(&mut self, event: ForensicEvent) -> Result<EvidenceEnvelope> {
+        let envelope = EvidenceEnvelope::create(self.last_hash.clone(), event)?;
+        writeln!(self.file, "{}", envelope.to_json_line()?)
+            .map_err(|error| BootforgeError::Io(error.to_string()))?;
+        self.file
+            .flush()
+            .map_err(|error| BootforgeError::Io(error.to_string()))?;
+        self.last_hash = Some(envelope.current_hash.clone());
+        self.records_written = self.records_written.saturating_add(1);
+        Ok(envelope)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn records_written(&self) -> u64 {
+        self.records_written
+    }
+
+    pub fn last_hash(&self) -> Option<&str> {
+        self.last_hash.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VerificationReport {
+    pub valid: bool,
+    pub records: u64,
+    pub first_invalid_record: Option<u64>,
+    pub last_hash: Option<String>,
+}
+
+pub fn verify_session(path: impl AsRef<Path>) -> Result<VerificationReport> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Ok(VerificationReport {
+            valid: true,
+            records: 0,
+            first_invalid_record: None,
+            last_hash: None,
+        });
+    }
+
+    let file = File::open(path).map_err(|error| BootforgeError::Io(error.to_string()))?;
+    let mut previous_hash: Option<String> = None;
+    let mut records = 0_u64;
+
+    for line in BufReader::new(file).lines() {
+        let line = line.map_err(|error| BootforgeError::Io(error.to_string()))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        records = records.saturating_add(1);
+        let envelope: EvidenceEnvelope = serde_json::from_str(&line)
+            .map_err(|error| BootforgeError::JsonSerializationFailed(error.to_string()))?;
+        if !envelope.verify(previous_hash.as_deref())? {
+            return Ok(VerificationReport {
+                valid: false,
+                records,
+                first_invalid_record: Some(records),
+                last_hash: previous_hash,
+            });
+        }
+        previous_hash = Some(envelope.current_hash);
+    }
+
+    Ok(VerificationReport {
+        valid: true,
+        records,
+        first_invalid_record: None,
+        last_hash: previous_hash,
+    })
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}


### PR DESCRIPTION
## Scope

Concentrated release-engineering pass for the low-level, read-only BootForge USB forensic library.

## Added

- tamper-evident append-only JSONL evidence envelopes
- SHA-256 record chaining with full-chain verification
- safe session resume that refuses altered evidence
- public `SessionRecorder`, `EvidenceEnvelope`, and `VerificationReport` API
- live passive recording example
- Windows/Linux/macOS CI matrix
- format, check, Clippy, tests, Rustdoc, and ARCWYRE feature gates
- explicit forensic validation and hardware-receipt matrix

## Safety boundary

This PR adds no formatting, flashing, firmware writing, driver installation, driver binding, filesystem mutation, device unlocking, or active probing behavior. USB interaction remains read-only-first.

## Validation status

- Implemented: yes
- Integrated: yes
- Rust CI: passed
- Compliance Guard: passed
- Forensic USB Core on Windows: passed
- Forensic USB Core on Linux: passed
- Forensic USB Core on macOS: passed
- ARCWYRE feature contract: passed
- Rustdoc warnings: passed
- Phoenix Key Windows Desktop compatibility: passed
- Hardware validated: no
- Release candidate: no

## Review focus

1. evidence-chain canonical payload stability
2. resume behavior after alteration or truncation
3. public API naming before v1 lock
4. hardware-validation plan and receipts
5. merge readiness for the R1 software-validation milestone
