### PR TITLE
Forensic USB R2: topology, lifetime tracking, and versioned fingerprints

### DIFF
--- a/.github/workflows/r2-autoformat.yml
+++ b/.github/workflows/r2-autoformat.yml
@@ -1,0 +1,33 @@
+name: R2 Autoformat
+
+on:
+  push:
+    branches:
+      - feat/forensic-usb-r2-topology-lifetime-fingerprint
+
+permissions:
+  contents: write
+
+jobs:
+  rustfmt:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: feat/forensic-usb-r2-topology-lifetime-fingerprint
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all
+      - name: Commit formatting
+        run: |
+          if git diff --quiet; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "style: format R2 forensic USB workspace"
+          git push

--- a/.github/workflows/r2-autoformat.yml
+++ b/.github/workflows/r2-autoformat.yml
@@ -12,22 +12,26 @@ jobs:
   rustfmt:
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
           ref: feat/forensic-usb-r2-topology-lifetime-fingerprint
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
       - run: cargo fmt --all
       - name: Commit formatting
+        shell: bash
         run: |
           if git diff --quiet; then
+            echo "Workspace already formatted"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .
+          git add --all
           git commit -m "style: format R2 forensic USB workspace"
-          git push
+          git push origin HEAD:feat/forensic-usb-r2-topology-lifetime-fingerprint

--- a/docs/R4_ENTERPRISE_SDK_PLAN.md
+++ b/docs/R4_ENTERPRISE_SDK_PLAN.md
@@ -1,0 +1,49 @@
+# BootForge USB R4 Enterprise SDK Plan
+
+R4 begins only after R2 and R3 are green, merged, and software-validated.
+
+## Scope
+
+### Stable API and compatibility
+- lock the Rust public API v1 surface
+- semantic-versioning and deprecation policy
+- API compatibility snapshots and compile tests
+- feature-flag policy and minimal dependency profile
+- sync, async, callback, and streaming contracts
+
+### Language bindings
+- C ABI and generated headers
+- Python bindings
+- C# bindings
+- Swift bindings
+- Kotlin bindings
+- Node.js bindings
+- language-specific examples and package publishing gates
+
+### Security and supply chain
+- unsafe Rust audit
+- dependency and license audits
+- SBOM generation
+- reproducible builds
+- signed artifacts and checksums
+- provenance attestations
+- release signing and verification guidance
+
+### Performance certification
+- scan/event latency benchmarks
+- bounded memory targets
+- dropped-event accounting
+- 1/10/50/100/250-device synthetic matrices
+- hub cascade and composite-device benchmarks
+- seven-day soak testing
+
+### Hardware validation
+- Windows, Linux, macOS, and ARCWYRE receipts
+- direct port, powered hub, bus-powered hub, dock, USB-C, and Thunderbolt matrices
+- Android mode transitions
+- Apple recovery and DFU
+- MTP, PTP, CDC, storage, HID, and composite devices
+
+## Release gates
+
+R4 may be called a release candidate only when all required software gates pass and named physical hardware receipts exist. No inferred or marketing-grade validation is permitted.

--- a/libbootforge/src/fingerprint.rs
+++ b/libbootforge/src/fingerprint.rs
@@ -7,10 +7,24 @@ use sha2::{Digest, Sha256};
 pub const FORENSIC_FINGERPRINT_SCHEMA_VERSION: u16 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum ForensicFingerprintConfidence { Weak, Moderate, Strong, Exact }
+pub enum ForensicFingerprintConfidence {
+    Weak,
+    Moderate,
+    Strong,
+    Exact,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum ForensicFingerprintEvidence { VendorProduct, SerialNumber, Manufacturer, ProductName, Platform, Transport, Mode, MatchedProfile }
+pub enum ForensicFingerprintEvidence {
+    VendorProduct,
+    SerialNumber,
+    Manufacturer,
+    ProductName,
+    Platform,
+    Transport,
+    Mode,
+    MatchedProfile,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForensicFingerprint {
@@ -22,23 +36,92 @@ pub struct ForensicFingerprint {
 
 impl ForensicFingerprint {
     pub fn from_device(device: &DeviceInfo) -> Self {
-        let mut evidence = vec![ForensicFingerprintEvidence::VendorProduct, ForensicFingerprintEvidence::Platform, ForensicFingerprintEvidence::Transport, ForensicFingerprintEvidence::Mode];
+        let mut evidence = vec![
+            ForensicFingerprintEvidence::VendorProduct,
+            ForensicFingerprintEvidence::Platform,
+            ForensicFingerprintEvidence::Transport,
+            ForensicFingerprintEvidence::Mode,
+        ];
         let serial = normalized(device.serial_number.as_deref());
         let manufacturer = normalized(device.manufacturer.as_deref());
         let product = normalized(device.product_name.as_deref());
         let profile = normalized(device.matched_profile.as_deref());
-        if serial.is_some() { evidence.push(ForensicFingerprintEvidence::SerialNumber); }
-        if manufacturer.is_some() { evidence.push(ForensicFingerprintEvidence::Manufacturer); }
-        if product.is_some() { evidence.push(ForensicFingerprintEvidence::ProductName); }
-        if profile.is_some() { evidence.push(ForensicFingerprintEvidence::MatchedProfile); }
-        let canonical = format!("v{}|{:04x}|{:04x}|{}|{}|{}|{}|{}|{}|{}", FORENSIC_FINGERPRINT_SCHEMA_VERSION, device.vendor_id, device.product_id, serial.as_deref().unwrap_or(""), manufacturer.as_deref().unwrap_or(""), product.as_deref().unwrap_or(""), platform(device.platform), transport(device.transport), mode(device.mode), profile.as_deref().unwrap_or(""));
+        if serial.is_some() {
+            evidence.push(ForensicFingerprintEvidence::SerialNumber);
+        }
+        if manufacturer.is_some() {
+            evidence.push(ForensicFingerprintEvidence::Manufacturer);
+        }
+        if product.is_some() {
+            evidence.push(ForensicFingerprintEvidence::ProductName);
+        }
+        if profile.is_some() {
+            evidence.push(ForensicFingerprintEvidence::MatchedProfile);
+        }
+        let canonical = format!(
+            "v{}|{:04x}|{:04x}|{}|{}|{}|{}|{}|{}|{}",
+            FORENSIC_FINGERPRINT_SCHEMA_VERSION,
+            device.vendor_id,
+            device.product_id,
+            serial.as_deref().unwrap_or(""),
+            manufacturer.as_deref().unwrap_or(""),
+            product.as_deref().unwrap_or(""),
+            platform(device.platform),
+            transport(device.transport),
+            mode(device.mode),
+            profile.as_deref().unwrap_or("")
+        );
         let value = format!("bffp1-{:x}", Sha256::digest(canonical.as_bytes()));
-        let confidence = if serial.is_some() && manufacturer.is_some() && product.is_some() { ForensicFingerprintConfidence::Exact } else if serial.is_some() || (manufacturer.is_some() && product.is_some() && profile.is_some()) { ForensicFingerprintConfidence::Strong } else if manufacturer.is_some() || product.is_some() || profile.is_some() { ForensicFingerprintConfidence::Moderate } else { ForensicFingerprintConfidence::Weak };
-        Self { schema_version: FORENSIC_FINGERPRINT_SCHEMA_VERSION, value, confidence, evidence }
+        let confidence = if serial.is_some() && manufacturer.is_some() && product.is_some() {
+            ForensicFingerprintConfidence::Exact
+        } else if serial.is_some()
+            || (manufacturer.is_some() && product.is_some() && profile.is_some())
+        {
+            ForensicFingerprintConfidence::Strong
+        } else if manufacturer.is_some() || product.is_some() || profile.is_some() {
+            ForensicFingerprintConfidence::Moderate
+        } else {
+            ForensicFingerprintConfidence::Weak
+        };
+        Self {
+            schema_version: FORENSIC_FINGERPRINT_SCHEMA_VERSION,
+            value,
+            confidence,
+            evidence,
+        }
     }
 }
 
-fn normalized(value: Option<&str>) -> Option<String> { value.map(str::trim).filter(|value| !value.is_empty()).map(|value| value.to_ascii_lowercase()) }
-fn platform(value: DevicePlatform) -> &'static str { match value { DevicePlatform::Apple => "apple", DevicePlatform::Android => "android", DevicePlatform::GenericUsb => "generic", DevicePlatform::Unknown => "unknown" } }
-fn transport(value: DeviceTransport) -> &'static str { match value { DeviceTransport::Usb2 => "usb2", DeviceTransport::Usb3 => "usb3", DeviceTransport::Unknown => "unknown" } }
-fn mode(value: DeviceMode) -> &'static str { match value { DeviceMode::Normal => "normal", DeviceMode::Recovery => "recovery", DeviceMode::Dfu => "dfu", DeviceMode::Bootloader => "bootloader", DeviceMode::Fastboot => "fastboot", DeviceMode::Adb => "adb", DeviceMode::MassStorage => "mass-storage", DeviceMode::Unknown => "unknown" } }
+fn normalized(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_ascii_lowercase())
+}
+fn platform(value: DevicePlatform) -> &'static str {
+    match value {
+        DevicePlatform::Apple => "apple",
+        DevicePlatform::Android => "android",
+        DevicePlatform::GenericUsb => "generic",
+        DevicePlatform::Unknown => "unknown",
+    }
+}
+fn transport(value: DeviceTransport) -> &'static str {
+    match value {
+        DeviceTransport::Usb2 => "usb2",
+        DeviceTransport::Usb3 => "usb3",
+        DeviceTransport::Unknown => "unknown",
+    }
+}
+fn mode(value: DeviceMode) -> &'static str {
+    match value {
+        DeviceMode::Normal => "normal",
+        DeviceMode::Recovery => "recovery",
+        DeviceMode::Dfu => "dfu",
+        DeviceMode::Bootloader => "bootloader",
+        DeviceMode::Fastboot => "fastboot",
+        DeviceMode::Adb => "adb",
+        DeviceMode::MassStorage => "mass-storage",
+        DeviceMode::Unknown => "unknown",
+    }
+}

--- a/libbootforge/src/fingerprint.rs
+++ b/libbootforge/src/fingerprint.rs
@@ -1,0 +1,44 @@
+//! Deterministic versioned forensic fingerprints for passive USB observations.
+
+use crate::{DeviceInfo, DeviceMode, DevicePlatform, DeviceTransport};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const FORENSIC_FINGERPRINT_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ForensicFingerprintConfidence { Weak, Moderate, Strong, Exact }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ForensicFingerprintEvidence { VendorProduct, SerialNumber, Manufacturer, ProductName, Platform, Transport, Mode, MatchedProfile }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForensicFingerprint {
+    pub schema_version: u16,
+    pub value: String,
+    pub confidence: ForensicFingerprintConfidence,
+    pub evidence: Vec<ForensicFingerprintEvidence>,
+}
+
+impl ForensicFingerprint {
+    pub fn from_device(device: &DeviceInfo) -> Self {
+        let mut evidence = vec![ForensicFingerprintEvidence::VendorProduct, ForensicFingerprintEvidence::Platform, ForensicFingerprintEvidence::Transport, ForensicFingerprintEvidence::Mode];
+        let serial = normalized(device.serial_number.as_deref());
+        let manufacturer = normalized(device.manufacturer.as_deref());
+        let product = normalized(device.product_name.as_deref());
+        let profile = normalized(device.matched_profile.as_deref());
+        if serial.is_some() { evidence.push(ForensicFingerprintEvidence::SerialNumber); }
+        if manufacturer.is_some() { evidence.push(ForensicFingerprintEvidence::Manufacturer); }
+        if product.is_some() { evidence.push(ForensicFingerprintEvidence::ProductName); }
+        if profile.is_some() { evidence.push(ForensicFingerprintEvidence::MatchedProfile); }
+        let canonical = format!("v{}|{:04x}|{:04x}|{}|{}|{}|{}|{}|{}|{}", FORENSIC_FINGERPRINT_SCHEMA_VERSION, device.vendor_id, device.product_id, serial.as_deref().unwrap_or(""), manufacturer.as_deref().unwrap_or(""), product.as_deref().unwrap_or(""), platform(device.platform), transport(device.transport), mode(device.mode), profile.as_deref().unwrap_or(""));
+        let value = format!("bffp1-{:x}", Sha256::digest(canonical.as_bytes()));
+        let confidence = if serial.is_some() && manufacturer.is_some() && product.is_some() { ForensicFingerprintConfidence::Exact } else if serial.is_some() || (manufacturer.is_some() && product.is_some() && profile.is_some()) { ForensicFingerprintConfidence::Strong } else if manufacturer.is_some() || product.is_some() || profile.is_some() { ForensicFingerprintConfidence::Moderate } else { ForensicFingerprintConfidence::Weak };
+        Self { schema_version: FORENSIC_FINGERPRINT_SCHEMA_VERSION, value, confidence, evidence }
+    }
+}
+
+fn normalized(value: Option<&str>) -> Option<String> { value.map(str::trim).filter(|value| !value.is_empty()).map(|value| value.to_ascii_lowercase()) }
+fn platform(value: DevicePlatform) -> &'static str { match value { DevicePlatform::Apple => "apple", DevicePlatform::Android => "android", DevicePlatform::GenericUsb => "generic", DevicePlatform::Unknown => "unknown" } }
+fn transport(value: DeviceTransport) -> &'static str { match value { DeviceTransport::Usb2 => "usb2", DeviceTransport::Usb3 => "usb3", DeviceTransport::Unknown => "unknown" } }
+fn mode(value: DeviceMode) -> &'static str { match value { DeviceMode::Normal => "normal", DeviceMode::Recovery => "recovery", DeviceMode::Dfu => "dfu", DeviceMode::Bootloader => "bootloader", DeviceMode::Fastboot => "fastboot", DeviceMode::Adb => "adb", DeviceMode::MassStorage => "mass-storage", DeviceMode::Unknown => "unknown" } }

--- a/libbootforge/src/lib.rs
+++ b/libbootforge/src/lib.rs
@@ -7,14 +7,17 @@ pub mod detect;
 pub mod driver;
 pub mod driver_watch;
 pub mod error;
+pub mod fingerprint;
 pub mod forensic;
 pub mod health;
 pub mod identity;
+pub mod lifetime;
 pub mod native_driver;
 pub mod notification;
 pub mod protocol;
 pub mod recorder;
 pub mod session;
+pub mod topology;
 pub mod types;
 
 pub mod descriptors;
@@ -30,23 +33,17 @@ pub use driver::{
 pub use driver_watch::{DriverChange, DriverChangeField, DriverChangeMonitor, DriverStateTracker};
 pub use error::{BootforgeError, Result};
 pub use events::ForensicEventMonitor;
+pub use fingerprint::{ForensicFingerprint, ForensicFingerprintConfidence, ForensicFingerprintEvidence, FORENSIC_FINGERPRINT_SCHEMA_VERSION};
 pub use forensic::{ForensicEvent, ForensicEventKind, ObservationSource};
 pub use health::{HealthReport, HealthSignal, HealthState, HealthTracker};
-pub use identity::{
-    correlate_reconnect, DeviceIdentity, IdentityConfidence, IdentityEvidence, ReconnectMatch,
-};
+pub use identity::{correlate_reconnect, DeviceIdentity, IdentityConfidence, IdentityEvidence, ReconnectMatch};
+pub use lifetime::{DeviceLifetime, LifetimeTracker};
 pub use native_driver::inspect_platform_driver;
 pub use notification::{NotificationSignal, NotificationWake, PollingWake, WakeReason, WakeResult};
-pub use protocol::{
-    ProtocolConfidence, ProtocolEvidence, ProtocolObservation, ProtocolReport, UsbProtocol,
-};
-pub use recorder::{
-    verify_session, EvidenceEnvelope, SessionRecorder, VerificationReport, RECORD_SCHEMA_VERSION,
-};
-pub use types::{
-    DeviceFamily, DeviceFingerprint, DeviceInfo, DeviceMode, DevicePlatform, DeviceTransport,
-    FingerprintConfidence, WorkflowRecommendation,
-};
+pub use protocol::{ProtocolConfidence, ProtocolEvidence, ProtocolObservation, ProtocolReport, UsbProtocol};
+pub use recorder::{verify_session, EvidenceEnvelope, SessionRecorder, VerificationReport, RECORD_SCHEMA_VERSION};
+pub use topology::{TopologyNode, TopologyNodeKind, TopologyPath, TopologySnapshot};
+pub use types::{DeviceFamily, DeviceFingerprint, DeviceInfo, DeviceMode, DevicePlatform, DeviceTransport, FingerprintConfidence, WorkflowRecommendation};
 
 pub use descriptors::DeviceDescriptor;
 pub use enumeration::enumerate_devices;
@@ -56,6 +53,10 @@ pub fn scan_devices_json() -> Result<String> {
     let devices = scan_devices()?;
     serde_json::to_string_pretty(&devices)
         .map_err(|error| BootforgeError::JsonSerializationFailed(error.to_string()))
+}
+
+pub fn scan_topology() -> Result<TopologySnapshot> {
+    Ok(TopologySnapshot::from_devices(&scan_devices()?))
 }
 
 #[cfg(test)]
@@ -80,6 +81,9 @@ mod tests {
         let _watcher: Option<ForensicEventMonitor> = None;
         let _envelope: Option<EvidenceEnvelope> = None;
         let _verification: Option<VerificationReport> = None;
+        let _topology: Option<TopologySnapshot> = None;
+        let _lifetime: Option<DeviceLifetime> = None;
+        let _fingerprint: Option<ForensicFingerprint> = None;
         let _router: fn(&DeviceInfo) -> DriverReport = inspect_platform_driver;
     }
 }

--- a/libbootforge/src/lib.rs
+++ b/libbootforge/src/lib.rs
@@ -33,17 +33,29 @@ pub use driver::{
 pub use driver_watch::{DriverChange, DriverChangeField, DriverChangeMonitor, DriverStateTracker};
 pub use error::{BootforgeError, Result};
 pub use events::ForensicEventMonitor;
-pub use fingerprint::{ForensicFingerprint, ForensicFingerprintConfidence, ForensicFingerprintEvidence, FORENSIC_FINGERPRINT_SCHEMA_VERSION};
+pub use fingerprint::{
+    ForensicFingerprint, ForensicFingerprintConfidence, ForensicFingerprintEvidence,
+    FORENSIC_FINGERPRINT_SCHEMA_VERSION,
+};
 pub use forensic::{ForensicEvent, ForensicEventKind, ObservationSource};
 pub use health::{HealthReport, HealthSignal, HealthState, HealthTracker};
-pub use identity::{correlate_reconnect, DeviceIdentity, IdentityConfidence, IdentityEvidence, ReconnectMatch};
+pub use identity::{
+    correlate_reconnect, DeviceIdentity, IdentityConfidence, IdentityEvidence, ReconnectMatch,
+};
 pub use lifetime::{DeviceLifetime, LifetimeTracker};
 pub use native_driver::inspect_platform_driver;
 pub use notification::{NotificationSignal, NotificationWake, PollingWake, WakeReason, WakeResult};
-pub use protocol::{ProtocolConfidence, ProtocolEvidence, ProtocolObservation, ProtocolReport, UsbProtocol};
-pub use recorder::{verify_session, EvidenceEnvelope, SessionRecorder, VerificationReport, RECORD_SCHEMA_VERSION};
+pub use protocol::{
+    ProtocolConfidence, ProtocolEvidence, ProtocolObservation, ProtocolReport, UsbProtocol,
+};
+pub use recorder::{
+    verify_session, EvidenceEnvelope, SessionRecorder, VerificationReport, RECORD_SCHEMA_VERSION,
+};
 pub use topology::{TopologyNode, TopologyNodeKind, TopologyPath, TopologySnapshot};
-pub use types::{DeviceFamily, DeviceFingerprint, DeviceInfo, DeviceMode, DevicePlatform, DeviceTransport, FingerprintConfidence, WorkflowRecommendation};
+pub use types::{
+    DeviceFamily, DeviceFingerprint, DeviceInfo, DeviceMode, DevicePlatform, DeviceTransport,
+    FingerprintConfidence, WorkflowRecommendation,
+};
 
 pub use descriptors::DeviceDescriptor;
 pub use enumeration::enumerate_devices;

--- a/libbootforge/src/lifetime.rs
+++ b/libbootforge/src/lifetime.rs
@@ -21,11 +21,25 @@ pub struct DeviceLifetime {
 
 impl DeviceLifetime {
     fn new(event: &ForensicEvent) -> Self {
-        Self { device_id: event.device_id.clone(), first_seen: event.timestamp, last_seen: event.timestamp, sessions: 0, disconnects: 0, reconnects: 0, mode_changes: 0, observed_events: 0, accumulated_runtime_ms: 0, connected_since: None }
+        Self {
+            device_id: event.device_id.clone(),
+            first_seen: event.timestamp,
+            last_seen: event.timestamp,
+            sessions: 0,
+            disconnects: 0,
+            reconnects: 0,
+            mode_changes: 0,
+            observed_events: 0,
+            accumulated_runtime_ms: 0,
+            connected_since: None,
+        }
     }
 
     pub fn total_runtime(&self, now: DateTime<Utc>) -> Duration {
-        let active = self.connected_since.map(|start| now - start).unwrap_or_else(Duration::zero);
+        let active = self
+            .connected_since
+            .map(|start| now - start)
+            .unwrap_or_else(Duration::zero);
         Duration::milliseconds(self.accumulated_runtime_ms) + active
     }
 }
@@ -37,7 +51,10 @@ pub struct LifetimeTracker {
 
 impl LifetimeTracker {
     pub fn observe(&mut self, event: &ForensicEvent) -> &DeviceLifetime {
-        let record = self.records.entry(event.device_id.clone()).or_insert_with(|| DeviceLifetime::new(event));
+        let record = self
+            .records
+            .entry(event.device_id.clone())
+            .or_insert_with(|| DeviceLifetime::new(event));
         record.last_seen = event.timestamp;
         record.observed_events = record.observed_events.saturating_add(1);
         match event.kind {
@@ -57,31 +74,49 @@ impl LifetimeTracker {
             ForensicEventKind::DeviceDisconnected => {
                 record.disconnects = record.disconnects.saturating_add(1);
                 if let Some(start) = record.connected_since.take() {
-                    record.accumulated_runtime_ms = record.accumulated_runtime_ms.saturating_add((event.timestamp - start).num_milliseconds().max(0));
+                    record.accumulated_runtime_ms = record
+                        .accumulated_runtime_ms
+                        .saturating_add((event.timestamp - start).num_milliseconds().max(0));
                 }
             }
-            ForensicEventKind::ModeChanged => record.mode_changes = record.mode_changes.saturating_add(1),
+            ForensicEventKind::ModeChanged => {
+                record.mode_changes = record.mode_changes.saturating_add(1)
+            }
             _ => {}
         }
         record
     }
 
-    pub fn get(&self, device_id: &str) -> Option<&DeviceLifetime> { self.records.get(device_id) }
-    pub fn records(&self) -> impl Iterator<Item = &DeviceLifetime> { self.records.values() }
+    pub fn get(&self, device_id: &str) -> Option<&DeviceLifetime> {
+        self.records.get(device_id)
+    }
+    pub fn records(&self) -> impl Iterator<Item = &DeviceLifetime> {
+        self.records.values()
+    }
     pub fn merge_identity(&mut self, previous_id: &str, current_id: &str) {
-        if previous_id == current_id { return; }
+        if previous_id == current_id {
+            return;
+        }
         if let Some(mut previous) = self.records.remove(previous_id) {
             previous.device_id = current_id.to_string();
-            self.records.entry(current_id.to_string()).and_modify(|current| {
-                current.first_seen = current.first_seen.min(previous.first_seen);
-                current.last_seen = current.last_seen.max(previous.last_seen);
-                current.sessions = current.sessions.saturating_add(previous.sessions);
-                current.disconnects = current.disconnects.saturating_add(previous.disconnects);
-                current.reconnects = current.reconnects.saturating_add(previous.reconnects);
-                current.mode_changes = current.mode_changes.saturating_add(previous.mode_changes);
-                current.observed_events = current.observed_events.saturating_add(previous.observed_events);
-                current.accumulated_runtime_ms = current.accumulated_runtime_ms.saturating_add(previous.accumulated_runtime_ms);
-            }).or_insert(previous);
+            self.records
+                .entry(current_id.to_string())
+                .and_modify(|current| {
+                    current.first_seen = current.first_seen.min(previous.first_seen);
+                    current.last_seen = current.last_seen.max(previous.last_seen);
+                    current.sessions = current.sessions.saturating_add(previous.sessions);
+                    current.disconnects = current.disconnects.saturating_add(previous.disconnects);
+                    current.reconnects = current.reconnects.saturating_add(previous.reconnects);
+                    current.mode_changes =
+                        current.mode_changes.saturating_add(previous.mode_changes);
+                    current.observed_events = current
+                        .observed_events
+                        .saturating_add(previous.observed_events);
+                    current.accumulated_runtime_ms = current
+                        .accumulated_runtime_ms
+                        .saturating_add(previous.accumulated_runtime_ms);
+                })
+                .or_insert(previous);
         }
     }
 }

--- a/libbootforge/src/lifetime.rs
+++ b/libbootforge/src/lifetime.rs
@@ -23,8 +23,8 @@ impl DeviceLifetime {
     fn new(event: &ForensicEvent) -> Self {
         Self {
             device_id: event.device_id.clone(),
-            first_seen: event.timestamp,
-            last_seen: event.timestamp,
+            first_seen: event.observed_at,
+            last_seen: event.observed_at,
             sessions: 0,
             disconnects: 0,
             reconnects: 0,
@@ -55,20 +55,20 @@ impl LifetimeTracker {
             .records
             .entry(event.device_id.clone())
             .or_insert_with(|| DeviceLifetime::new(event));
-        record.last_seen = event.timestamp;
+        record.last_seen = event.observed_at;
         record.observed_events = record.observed_events.saturating_add(1);
         match event.kind {
             ForensicEventKind::DeviceConnected => {
                 if record.connected_since.is_none() {
                     record.sessions = record.sessions.saturating_add(1);
-                    record.connected_since = Some(event.timestamp);
+                    record.connected_since = Some(event.observed_at);
                 }
             }
             ForensicEventKind::DeviceReconnected => {
                 record.reconnects = record.reconnects.saturating_add(1);
                 if record.connected_since.is_none() {
                     record.sessions = record.sessions.saturating_add(1);
-                    record.connected_since = Some(event.timestamp);
+                    record.connected_since = Some(event.observed_at);
                 }
             }
             ForensicEventKind::DeviceDisconnected => {
@@ -76,7 +76,7 @@ impl LifetimeTracker {
                 if let Some(start) = record.connected_since.take() {
                     record.accumulated_runtime_ms = record
                         .accumulated_runtime_ms
-                        .saturating_add((event.timestamp - start).num_milliseconds().max(0));
+                        .saturating_add((event.observed_at - start).num_milliseconds().max(0));
                 }
             }
             ForensicEventKind::ModeChanged => {
@@ -90,9 +90,11 @@ impl LifetimeTracker {
     pub fn get(&self, device_id: &str) -> Option<&DeviceLifetime> {
         self.records.get(device_id)
     }
+
     pub fn records(&self) -> impl Iterator<Item = &DeviceLifetime> {
         self.records.values()
     }
+
     pub fn merge_identity(&mut self, previous_id: &str, current_id: &str) {
         if previous_id == current_id {
             return;

--- a/libbootforge/src/lifetime.rs
+++ b/libbootforge/src/lifetime.rs
@@ -1,0 +1,87 @@
+//! Persistent per-device lifetime accounting driven by normalized forensic events.
+
+use crate::{ForensicEvent, ForensicEventKind};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeviceLifetime {
+    pub device_id: String,
+    pub first_seen: DateTime<Utc>,
+    pub last_seen: DateTime<Utc>,
+    pub sessions: u64,
+    pub disconnects: u64,
+    pub reconnects: u64,
+    pub mode_changes: u64,
+    pub observed_events: u64,
+    pub accumulated_runtime_ms: i64,
+    pub connected_since: Option<DateTime<Utc>>,
+}
+
+impl DeviceLifetime {
+    fn new(event: &ForensicEvent) -> Self {
+        Self { device_id: event.device_id.clone(), first_seen: event.timestamp, last_seen: event.timestamp, sessions: 0, disconnects: 0, reconnects: 0, mode_changes: 0, observed_events: 0, accumulated_runtime_ms: 0, connected_since: None }
+    }
+
+    pub fn total_runtime(&self, now: DateTime<Utc>) -> Duration {
+        let active = self.connected_since.map(|start| now - start).unwrap_or_else(Duration::zero);
+        Duration::milliseconds(self.accumulated_runtime_ms) + active
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct LifetimeTracker {
+    records: BTreeMap<String, DeviceLifetime>,
+}
+
+impl LifetimeTracker {
+    pub fn observe(&mut self, event: &ForensicEvent) -> &DeviceLifetime {
+        let record = self.records.entry(event.device_id.clone()).or_insert_with(|| DeviceLifetime::new(event));
+        record.last_seen = event.timestamp;
+        record.observed_events = record.observed_events.saturating_add(1);
+        match event.kind {
+            ForensicEventKind::DeviceConnected => {
+                if record.connected_since.is_none() {
+                    record.sessions = record.sessions.saturating_add(1);
+                    record.connected_since = Some(event.timestamp);
+                }
+            }
+            ForensicEventKind::DeviceReconnected => {
+                record.reconnects = record.reconnects.saturating_add(1);
+                if record.connected_since.is_none() {
+                    record.sessions = record.sessions.saturating_add(1);
+                    record.connected_since = Some(event.timestamp);
+                }
+            }
+            ForensicEventKind::DeviceDisconnected => {
+                record.disconnects = record.disconnects.saturating_add(1);
+                if let Some(start) = record.connected_since.take() {
+                    record.accumulated_runtime_ms = record.accumulated_runtime_ms.saturating_add((event.timestamp - start).num_milliseconds().max(0));
+                }
+            }
+            ForensicEventKind::ModeChanged => record.mode_changes = record.mode_changes.saturating_add(1),
+            _ => {}
+        }
+        record
+    }
+
+    pub fn get(&self, device_id: &str) -> Option<&DeviceLifetime> { self.records.get(device_id) }
+    pub fn records(&self) -> impl Iterator<Item = &DeviceLifetime> { self.records.values() }
+    pub fn merge_identity(&mut self, previous_id: &str, current_id: &str) {
+        if previous_id == current_id { return; }
+        if let Some(mut previous) = self.records.remove(previous_id) {
+            previous.device_id = current_id.to_string();
+            self.records.entry(current_id.to_string()).and_modify(|current| {
+                current.first_seen = current.first_seen.min(previous.first_seen);
+                current.last_seen = current.last_seen.max(previous.last_seen);
+                current.sessions = current.sessions.saturating_add(previous.sessions);
+                current.disconnects = current.disconnects.saturating_add(previous.disconnects);
+                current.reconnects = current.reconnects.saturating_add(previous.reconnects);
+                current.mode_changes = current.mode_changes.saturating_add(previous.mode_changes);
+                current.observed_events = current.observed_events.saturating_add(previous.observed_events);
+                current.accumulated_runtime_ms = current.accumulated_runtime_ms.saturating_add(previous.accumulated_runtime_ms);
+            }).or_insert(previous);
+        }
+    }
+}

--- a/libbootforge/src/topology.rs
+++ b/libbootforge/src/topology.rs
@@ -45,7 +45,11 @@ impl TopologySnapshot {
                 id: controller_id.clone(),
                 parent_id: None,
                 kind: TopologyNodeKind::Controller,
-                path: TopologyPath { bus_number: device.bus_number, device_address: 0, ports: Vec::new() },
+                path: TopologyPath {
+                    bus_number: device.bus_number,
+                    device_address: 0,
+                    ports: Vec::new(),
+                },
                 vendor_id: None,
                 product_id: None,
                 label: Some(format!("USB controller bus {}", device.bus_number)),
@@ -55,43 +59,94 @@ impl TopologySnapshot {
                 id: root_id.clone(),
                 parent_id: Some(controller_id),
                 kind: TopologyNodeKind::RootHub,
-                path: TopologyPath { bus_number: device.bus_number, device_address: 0, ports: Vec::new() },
+                path: TopologyPath {
+                    bus_number: device.bus_number,
+                    device_address: 0,
+                    ports: Vec::new(),
+                },
                 vendor_id: None,
                 product_id: None,
                 label: Some(format!("Root hub bus {}", device.bus_number)),
             });
-            let id = format!("usb-{}-{}-{:04x}-{:04x}", device.bus_number, device.address, device.vendor_id, device.product_id);
-            nodes.insert(id.clone(), TopologyNode {
-                id,
-                parent_id: Some(root_id),
-                kind: TopologyNodeKind::Device,
-                path: TopologyPath { bus_number: device.bus_number, device_address: device.address, ports: Vec::new() },
-                vendor_id: Some(device.vendor_id),
-                product_id: Some(device.product_id),
-                label: device.product_name.clone().or_else(|| device.manufacturer.clone()),
-            });
+            let id = format!(
+                "usb-{}-{}-{:04x}-{:04x}",
+                device.bus_number, device.address, device.vendor_id, device.product_id
+            );
+            nodes.insert(
+                id.clone(),
+                TopologyNode {
+                    id,
+                    parent_id: Some(root_id),
+                    kind: TopologyNodeKind::Device,
+                    path: TopologyPath {
+                        bus_number: device.bus_number,
+                        device_address: device.address,
+                        ports: Vec::new(),
+                    },
+                    vendor_id: Some(device.vendor_id),
+                    product_id: Some(device.product_id),
+                    label: device
+                        .product_name
+                        .clone()
+                        .or_else(|| device.manufacturer.clone()),
+                },
+            );
         }
-        Self { nodes: nodes.into_values().collect() }
+        Self {
+            nodes: nodes.into_values().collect(),
+        }
     }
 
     pub fn children_of(&self, parent_id: &str) -> Vec<&TopologyNode> {
-        self.nodes.iter().filter(|node| node.parent_id.as_deref() == Some(parent_id)).collect()
+        self.nodes
+            .iter()
+            .filter(|node| node.parent_id.as_deref() == Some(parent_id))
+            .collect()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DeviceFamily, DeviceFingerprint, DeviceMode, DevicePlatform, DeviceTransport, FingerprintConfidence, WorkflowRecommendation};
+    use crate::{
+        DeviceFamily, DeviceFingerprint, DeviceMode, DevicePlatform, DeviceTransport,
+        FingerprintConfidence, WorkflowRecommendation,
+    };
 
     fn device(bus: u8, address: u8) -> DeviceInfo {
-        DeviceInfo { bus_number: bus, address, vendor_id: 0x1234, product_id: 0x5678, vendor_name: None, manufacturer: None, product_name: Some("Test".into()), serial_number: None, platform: DevicePlatform::GenericUsb, transport: DeviceTransport::Usb2, mode: DeviceMode::Normal, fingerprint: DeviceFingerprint { family: DeviceFamily::Peripheral, model_hint: None, confidence: FingerprintConfidence::Low }, recommended_workflow: WorkflowRecommendation::GenericPeripheralInspection, matched_profile: None }
+        DeviceInfo {
+            bus_number: bus,
+            address,
+            vendor_id: 0x1234,
+            product_id: 0x5678,
+            vendor_name: None,
+            manufacturer: None,
+            product_name: Some("Test".into()),
+            serial_number: None,
+            platform: DevicePlatform::GenericUsb,
+            transport: DeviceTransport::Usb2,
+            mode: DeviceMode::Normal,
+            fingerprint: DeviceFingerprint {
+                family: DeviceFamily::Peripheral,
+                model_hint: None,
+                confidence: FingerprintConfidence::Low,
+            },
+            recommended_workflow: WorkflowRecommendation::GenericPeripheralInspection,
+            matched_profile: None,
+        }
     }
 
     #[test]
     fn groups_devices_under_bus_root_hub() {
         let snapshot = TopologySnapshot::from_devices(&[device(1, 2), device(1, 3)]);
         assert_eq!(snapshot.children_of("root-hub-bus-1").len(), 2);
-        assert_eq!(snapshot.nodes.iter().filter(|n| n.kind == TopologyNodeKind::Controller).count(), 1);
+        assert_eq!(
+            snapshot
+                .nodes
+                .iter()
+                .filter(|n| n.kind == TopologyNodeKind::Controller)
+                .count(),
+            1
+        );
     }
 }

--- a/libbootforge/src/topology.rs
+++ b/libbootforge/src/topology.rs
@@ -1,0 +1,97 @@
+//! Normalized USB topology snapshots built from passive enumeration.
+
+use crate::DeviceInfo;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TopologyNodeKind {
+    Controller,
+    RootHub,
+    Hub,
+    Device,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TopologyPath {
+    pub bus_number: u8,
+    pub device_address: u8,
+    pub ports: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TopologyNode {
+    pub id: String,
+    pub parent_id: Option<String>,
+    pub kind: TopologyNodeKind,
+    pub path: TopologyPath,
+    pub vendor_id: Option<u16>,
+    pub product_id: Option<u16>,
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct TopologySnapshot {
+    pub nodes: Vec<TopologyNode>,
+}
+
+impl TopologySnapshot {
+    pub fn from_devices(devices: &[DeviceInfo]) -> Self {
+        let mut nodes = BTreeMap::new();
+        for device in devices {
+            let controller_id = format!("controller-bus-{}", device.bus_number);
+            nodes.entry(controller_id.clone()).or_insert(TopologyNode {
+                id: controller_id.clone(),
+                parent_id: None,
+                kind: TopologyNodeKind::Controller,
+                path: TopologyPath { bus_number: device.bus_number, device_address: 0, ports: Vec::new() },
+                vendor_id: None,
+                product_id: None,
+                label: Some(format!("USB controller bus {}", device.bus_number)),
+            });
+            let root_id = format!("root-hub-bus-{}", device.bus_number);
+            nodes.entry(root_id.clone()).or_insert(TopologyNode {
+                id: root_id.clone(),
+                parent_id: Some(controller_id),
+                kind: TopologyNodeKind::RootHub,
+                path: TopologyPath { bus_number: device.bus_number, device_address: 0, ports: Vec::new() },
+                vendor_id: None,
+                product_id: None,
+                label: Some(format!("Root hub bus {}", device.bus_number)),
+            });
+            let id = format!("usb-{}-{}-{:04x}-{:04x}", device.bus_number, device.address, device.vendor_id, device.product_id);
+            nodes.insert(id.clone(), TopologyNode {
+                id,
+                parent_id: Some(root_id),
+                kind: TopologyNodeKind::Device,
+                path: TopologyPath { bus_number: device.bus_number, device_address: device.address, ports: Vec::new() },
+                vendor_id: Some(device.vendor_id),
+                product_id: Some(device.product_id),
+                label: device.product_name.clone().or_else(|| device.manufacturer.clone()),
+            });
+        }
+        Self { nodes: nodes.into_values().collect() }
+    }
+
+    pub fn children_of(&self, parent_id: &str) -> Vec<&TopologyNode> {
+        self.nodes.iter().filter(|node| node.parent_id.as_deref() == Some(parent_id)).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DeviceFamily, DeviceFingerprint, DeviceMode, DevicePlatform, DeviceTransport, FingerprintConfidence, WorkflowRecommendation};
+
+    fn device(bus: u8, address: u8) -> DeviceInfo {
+        DeviceInfo { bus_number: bus, address, vendor_id: 0x1234, product_id: 0x5678, vendor_name: None, manufacturer: None, product_name: Some("Test".into()), serial_number: None, platform: DevicePlatform::GenericUsb, transport: DeviceTransport::Usb2, mode: DeviceMode::Normal, fingerprint: DeviceFingerprint { family: DeviceFamily::Peripheral, model_hint: None, confidence: FingerprintConfidence::Low }, recommended_workflow: WorkflowRecommendation::GenericPeripheralInspection, matched_profile: None }
+    }
+
+    #[test]
+    fn groups_devices_under_bus_root_hub() {
+        let snapshot = TopologySnapshot::from_devices(&[device(1, 2), device(1, 3)]);
+        assert_eq!(snapshot.children_of("root-hub-bus-1").len(), 2);
+        assert_eq!(snapshot.nodes.iter().filter(|n| n.kind == TopologyNodeKind::Controller).count(), 1);
+    }
+}


### PR DESCRIPTION
## Scope

First concentrated R2 intelligence layer for the low-level, read-only BootForge USB forensic library.

## Added

- normalized controller, root-hub, and device topology snapshots
- deterministic topology node identifiers and parent-child queries
- persistent per-device lifetime accounting
- first-seen, last-seen, sessions, disconnects, reconnects, mode changes, and accumulated runtime
- identity-history migration support for lifetime records
- versioned SHA-256 forensic fingerprints
- explicit fingerprint confidence and evidence
- public `scan_topology()` API and R2 type exports

## Safety boundary

No formatting, flashing, writing, driver installation, binding, device control, active probing, unlocking, or filesystem mutation behavior is introduced.

## Validation status

- Implemented: yes
- Integrated: yes
- Hosted CI: pending
- Hardware validated: no
- Release candidate: no

## Review focus

1. topology contract forward compatibility
2. lifetime session accounting semantics
3. fingerprint canonicalization and schema stability
4. cross-platform Clippy and test results
5. whether native port-path enrichment should land in R2.1
