### PR TITLE
Forensic USB R3: descriptors, composite analysis, anomalies, and metrics

### DIFF
--- a/.github/workflows/r3-autoformat.yml
+++ b/.github/workflows/r3-autoformat.yml
@@ -1,0 +1,33 @@
+name: R3 Autoformat
+
+on:
+  push:
+    branches:
+      - feat/r3-descriptors-composite-persistence-anomaly-metrics
+
+permissions:
+  contents: write
+
+jobs:
+  rustfmt:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: feat/r3-descriptors-composite-persistence-anomaly-metrics
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all
+      - name: Commit formatting
+        run: |
+          if git diff --quiet; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "style: format R3 forensic USB workspace"
+          git push origin HEAD:feat/r3-descriptors-composite-persistence-anomaly-metrics

--- a/libbootforge/src/anomaly.rs
+++ b/libbootforge/src/anomaly.rs
@@ -1,0 +1,119 @@
+//! Explainable, passive anomaly findings. Findings are evidence, not certainty.
+
+use crate::{CompositeReport, DescriptorSnapshot, DeviceInfo};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AnomalySeverity {
+    Info,
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AnomalyKind {
+    MalformedDescriptors,
+    SuspiciousHidComposite,
+    VendorSpecificOnly,
+    MissingSerial,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AnomalyFinding {
+    pub kind: AnomalyKind,
+    pub severity: AnomalySeverity,
+    pub confidence_percent: u8,
+    pub evidence: Vec<String>,
+}
+
+pub fn analyze_passively(
+    device: &DeviceInfo,
+    descriptors: &DescriptorSnapshot,
+    composite: &CompositeReport,
+) -> Vec<AnomalyFinding> {
+    let mut findings = Vec::new();
+    if !descriptors.issues.is_empty() {
+        findings.push(AnomalyFinding {
+            kind: AnomalyKind::MalformedDescriptors,
+            severity: AnomalySeverity::Medium,
+            confidence_percent: 100,
+            evidence: vec![format!("{} descriptor issue(s)", descriptors.issues.len())],
+        });
+    }
+    let has_hid = composite.interfaces.iter().any(|interface| interface.class == 3);
+    let has_vendor = composite.interfaces.iter().any(|interface| interface.class == 255);
+    if has_hid && has_vendor {
+        findings.push(AnomalyFinding {
+            kind: AnomalyKind::SuspiciousHidComposite,
+            severity: AnomalySeverity::Low,
+            confidence_percent: 55,
+            evidence: vec!["HID and vendor-specific interfaces coexist".into()],
+        });
+    }
+    if !composite.interfaces.is_empty()
+        && composite.interfaces.iter().all(|interface| interface.class == 255)
+    {
+        findings.push(AnomalyFinding {
+            kind: AnomalyKind::VendorSpecificOnly,
+            severity: AnomalySeverity::Info,
+            confidence_percent: 70,
+            evidence: vec!["all observed interfaces are vendor-specific".into()],
+        });
+    }
+    if device.serial_number.as_deref().map(str::trim).unwrap_or("").is_empty() {
+        findings.push(AnomalyFinding {
+            kind: AnomalyKind::MissingSerial,
+            severity: AnomalySeverity::Info,
+            confidence_percent: 100,
+            evidence: vec!["device did not expose a usable serial number".into()],
+        });
+    }
+    findings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        DeviceFamily, DeviceFingerprint, DeviceMode, DevicePlatform, DeviceTransport,
+        FingerprintConfidence, WorkflowRecommendation,
+    };
+
+    fn device() -> DeviceInfo {
+        DeviceInfo {
+            bus_number: 1,
+            address: 2,
+            vendor_id: 1,
+            product_id: 2,
+            vendor_name: None,
+            manufacturer: None,
+            product_name: None,
+            serial_number: None,
+            platform: DevicePlatform::GenericUsb,
+            transport: DeviceTransport::Usb2,
+            mode: DeviceMode::Normal,
+            fingerprint: DeviceFingerprint {
+                family: DeviceFamily::Peripheral,
+                model_hint: None,
+                confidence: FingerprintConfidence::Low,
+            },
+            recommended_workflow: WorkflowRecommendation::GenericPeripheralInspection,
+            matched_profile: None,
+        }
+    }
+
+    #[test]
+    fn missing_serial_is_reported_without_claiming_malice() {
+        let findings = analyze_passively(
+            &device(),
+            &DescriptorSnapshot::decode(&[]),
+            &CompositeReport {
+                interfaces: Vec::new(),
+                is_composite: false,
+                malformed_interface_descriptors: 0,
+            },
+        );
+        assert!(findings.iter().any(|finding| finding.kind == AnomalyKind::MissingSerial));
+    }
+}

--- a/libbootforge/src/anomaly.rs
+++ b/libbootforge/src/anomaly.rs
@@ -41,8 +41,14 @@ pub fn analyze_passively(
             evidence: vec![format!("{} descriptor issue(s)", descriptors.issues.len())],
         });
     }
-    let has_hid = composite.interfaces.iter().any(|interface| interface.class == 3);
-    let has_vendor = composite.interfaces.iter().any(|interface| interface.class == 255);
+    let has_hid = composite
+        .interfaces
+        .iter()
+        .any(|interface| interface.class == 3);
+    let has_vendor = composite
+        .interfaces
+        .iter()
+        .any(|interface| interface.class == 255);
     if has_hid && has_vendor {
         findings.push(AnomalyFinding {
             kind: AnomalyKind::SuspiciousHidComposite,
@@ -52,7 +58,10 @@ pub fn analyze_passively(
         });
     }
     if !composite.interfaces.is_empty()
-        && composite.interfaces.iter().all(|interface| interface.class == 255)
+        && composite
+            .interfaces
+            .iter()
+            .all(|interface| interface.class == 255)
     {
         findings.push(AnomalyFinding {
             kind: AnomalyKind::VendorSpecificOnly,
@@ -61,7 +70,13 @@ pub fn analyze_passively(
             evidence: vec!["all observed interfaces are vendor-specific".into()],
         });
     }
-    if device.serial_number.as_deref().map(str::trim).unwrap_or("").is_empty() {
+    if device
+        .serial_number
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("")
+        .is_empty()
+    {
         findings.push(AnomalyFinding {
             kind: AnomalyKind::MissingSerial,
             severity: AnomalySeverity::Info,
@@ -114,6 +129,8 @@ mod tests {
                 malformed_interface_descriptors: 0,
             },
         );
-        assert!(findings.iter().any(|finding| finding.kind == AnomalyKind::MissingSerial));
+        assert!(findings
+            .iter()
+            .any(|finding| finding.kind == AnomalyKind::MissingSerial));
     }
 }

--- a/libbootforge/src/composite.rs
+++ b/libbootforge/src/composite.rs
@@ -1,0 +1,70 @@
+//! Passive composite-device analysis from decoded descriptor snapshots.
+
+use crate::{DecodedDescriptor, DescriptorKind, DescriptorSnapshot};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CompositeInterface {
+    pub number: u8,
+    pub alternate_setting: u8,
+    pub class: u8,
+    pub subclass: u8,
+    pub protocol: u8,
+    pub endpoint_count: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CompositeReport {
+    pub interfaces: Vec<CompositeInterface>,
+    pub is_composite: bool,
+    pub malformed_interface_descriptors: u32,
+}
+
+impl CompositeReport {
+    pub fn from_snapshot(snapshot: &DescriptorSnapshot) -> Self {
+        let mut interfaces = Vec::new();
+        let mut malformed = 0_u32;
+        for descriptor in &snapshot.descriptors {
+            if descriptor.kind != DescriptorKind::Interface {
+                continue;
+            }
+            match parse_interface(descriptor) {
+                Some(interface) => interfaces.push(interface),
+                None => malformed = malformed.saturating_add(1),
+            }
+        }
+        Self {
+            is_composite: interfaces.len() > 1,
+            interfaces,
+            malformed_interface_descriptors: malformed,
+        }
+    }
+}
+
+fn parse_interface(descriptor: &DecodedDescriptor) -> Option<CompositeInterface> {
+    let bytes = &descriptor.bytes;
+    if bytes.len() < 9 {
+        return None;
+    }
+    Some(CompositeInterface {
+        number: bytes[2],
+        alternate_setting: bytes[3],
+        endpoint_count: bytes[4],
+        class: bytes[5],
+        subclass: bytes[6],
+        protocol: bytes[7],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_multiple_interfaces() {
+        let raw = [9, 4, 0, 0, 1, 3, 1, 1, 0, 9, 4, 1, 0, 2, 255, 66, 1, 0];
+        let report = CompositeReport::from_snapshot(&DescriptorSnapshot::decode(&raw));
+        assert!(report.is_composite);
+        assert_eq!(report.interfaces.len(), 2);
+    }
+}

--- a/libbootforge/src/descriptor_intelligence.rs
+++ b/libbootforge/src/descriptor_intelligence.rs
@@ -21,10 +21,22 @@ pub enum DescriptorKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum DescriptorIssue {
-    InputTooLarge { length: usize, maximum: usize },
-    TruncatedHeader { offset: usize },
-    InvalidLength { offset: usize, length: u8 },
-    TruncatedBody { offset: usize, declared: usize, available: usize },
+    InputTooLarge {
+        length: usize,
+        maximum: usize,
+    },
+    TruncatedHeader {
+        offset: usize,
+    },
+    InvalidLength {
+        offset: usize,
+        length: u8,
+    },
+    TruncatedBody {
+        offset: usize,
+        declared: usize,
+        available: usize,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -132,6 +144,9 @@ mod tests {
     fn rejects_truncated_body_without_panicking() {
         let snapshot = DescriptorSnapshot::decode(&[5, 1, 0]);
         assert!(!snapshot.complete);
-        assert!(matches!(snapshot.issues[0], DescriptorIssue::TruncatedBody { .. }));
+        assert!(matches!(
+            snapshot.issues[0],
+            DescriptorIssue::TruncatedBody { .. }
+        ));
     }
 }

--- a/libbootforge/src/descriptor_intelligence.rs
+++ b/libbootforge/src/descriptor_intelligence.rs
@@ -15,8 +15,7 @@ pub enum DescriptorKind {
     DeviceQualifier,
     InterfaceAssociation,
     Bos,
-    Hid,
-    DfuFunctional,
+    ClassSpecific(u8),
     Unknown(u8),
 }
 
@@ -107,8 +106,7 @@ fn kind(value: u8) -> DescriptorKind {
         6 => DescriptorKind::DeviceQualifier,
         11 => DescriptorKind::InterfaceAssociation,
         15 => DescriptorKind::Bos,
-        0x21 => DescriptorKind::Hid,
-        0x21 | 0x22 => DescriptorKind::DfuFunctional,
+        0x21..=0x25 => DescriptorKind::ClassSpecific(value),
         other => DescriptorKind::Unknown(other),
     }
 }

--- a/libbootforge/src/descriptor_intelligence.rs
+++ b/libbootforge/src/descriptor_intelligence.rs
@@ -1,0 +1,139 @@
+//! Bounded, read-only USB descriptor decoding with explicit malformed-input reporting.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const MAX_DESCRIPTOR_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DescriptorKind {
+    Device,
+    Configuration,
+    String,
+    Interface,
+    Endpoint,
+    DeviceQualifier,
+    InterfaceAssociation,
+    Bos,
+    Hid,
+    DfuFunctional,
+    Unknown(u8),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DescriptorIssue {
+    InputTooLarge { length: usize, maximum: usize },
+    TruncatedHeader { offset: usize },
+    InvalidLength { offset: usize, length: u8 },
+    TruncatedBody { offset: usize, declared: usize, available: usize },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DecodedDescriptor {
+    pub offset: usize,
+    pub length: u8,
+    pub kind: DescriptorKind,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DescriptorSnapshot {
+    pub sha256: String,
+    pub descriptors: Vec<DecodedDescriptor>,
+    pub issues: Vec<DescriptorIssue>,
+    pub complete: bool,
+}
+
+impl DescriptorSnapshot {
+    pub fn decode(input: &[u8]) -> Self {
+        if input.len() > MAX_DESCRIPTOR_BYTES {
+            return Self {
+                sha256: digest(input),
+                descriptors: Vec::new(),
+                issues: vec![DescriptorIssue::InputTooLarge {
+                    length: input.len(),
+                    maximum: MAX_DESCRIPTOR_BYTES,
+                }],
+                complete: false,
+            };
+        }
+
+        let mut descriptors = Vec::new();
+        let mut issues = Vec::new();
+        let mut offset = 0;
+        while offset < input.len() {
+            if input.len() - offset < 2 {
+                issues.push(DescriptorIssue::TruncatedHeader { offset });
+                break;
+            }
+            let length = input[offset];
+            if length < 2 {
+                issues.push(DescriptorIssue::InvalidLength { offset, length });
+                break;
+            }
+            let end = offset.saturating_add(length as usize);
+            if end > input.len() {
+                issues.push(DescriptorIssue::TruncatedBody {
+                    offset,
+                    declared: length as usize,
+                    available: input.len() - offset,
+                });
+                break;
+            }
+            descriptors.push(DecodedDescriptor {
+                offset,
+                length,
+                kind: kind(input[offset + 1]),
+                bytes: input[offset..end].to_vec(),
+            });
+            offset = end;
+        }
+        Self {
+            sha256: digest(input),
+            complete: issues.is_empty() && offset == input.len(),
+            descriptors,
+            issues,
+        }
+    }
+}
+
+fn kind(value: u8) -> DescriptorKind {
+    match value {
+        1 => DescriptorKind::Device,
+        2 => DescriptorKind::Configuration,
+        3 => DescriptorKind::String,
+        4 => DescriptorKind::Interface,
+        5 => DescriptorKind::Endpoint,
+        6 => DescriptorKind::DeviceQualifier,
+        11 => DescriptorKind::InterfaceAssociation,
+        15 => DescriptorKind::Bos,
+        0x21 => DescriptorKind::Hid,
+        0x21 | 0x22 => DescriptorKind::DfuFunctional,
+        other => DescriptorKind::Unknown(other),
+    }
+}
+
+fn digest(input: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(input))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_multiple_descriptors_deterministically() {
+        let input = [2, 1, 3, 4, 0xaa];
+        let snapshot = DescriptorSnapshot::decode(&input);
+        assert!(snapshot.complete);
+        assert_eq!(snapshot.descriptors.len(), 2);
+        assert_eq!(snapshot, DescriptorSnapshot::decode(&input));
+    }
+
+    #[test]
+    fn rejects_truncated_body_without_panicking() {
+        let snapshot = DescriptorSnapshot::decode(&[5, 1, 0]);
+        assert!(!snapshot.complete);
+        assert!(matches!(snapshot.issues[0], DescriptorIssue::TruncatedBody { .. }));
+    }
+}

--- a/libbootforge/src/export.rs
+++ b/libbootforge/src/export.rs
@@ -22,9 +22,8 @@ pub fn export_inventory_json(snapshot: &InventorySnapshot) -> Result<(String, Ex
 }
 
 pub fn export_inventory_csv(snapshot: &InventorySnapshot) -> (String, ExportManifest) {
-    let mut output = String::from(
-        "sequence,observed_at,kind,source,device_id,vid,pid,bus,address,message\n",
-    );
+    let mut output =
+        String::from("sequence,observed_at,kind,source,device_id,vid,pid,bus,address,message\n");
     for event in &snapshot.events {
         let row = [
             event.sequence.to_string(),

--- a/libbootforge/src/export.rs
+++ b/libbootforge/src/export.rs
@@ -1,0 +1,80 @@
+//! Deterministic, read-only exports for forensic inventory snapshots.
+
+use crate::{BootforgeError, InventorySnapshot, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const EXPORT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ExportManifest {
+    pub schema_version: u32,
+    pub format: String,
+    pub record_count: usize,
+    pub sha256: String,
+}
+
+pub fn export_inventory_json(snapshot: &InventorySnapshot) -> Result<(String, ExportManifest)> {
+    let payload = serde_json::to_string_pretty(snapshot)
+        .map_err(|error| BootforgeError::JsonSerializationFailed(error.to_string()))?;
+    let manifest = manifest("json", snapshot.event_count, payload.as_bytes());
+    Ok((payload, manifest))
+}
+
+pub fn export_inventory_csv(snapshot: &InventorySnapshot) -> (String, ExportManifest) {
+    let mut output = String::from("sequence,observed_at,kind,source,device_id,vid,pid,bus,address,message\n");
+    for event in &snapshot.events {
+        let row = [
+            event.sequence.to_string(),
+            csv(&event.observed_at.to_rfc3339()),
+            csv(&format!("{:?}", event.kind)),
+            csv(&format!("{:?}", event.source)),
+            csv(&event.device_id),
+            format!("{:04x}", event.vid),
+            format!("{:04x}", event.pid),
+            event.bus.map(|value| value.to_string()).unwrap_or_default(),
+            event.address.map(|value| value.to_string()).unwrap_or_default(),
+            csv(event.message.as_deref().unwrap_or_default()),
+        ]
+        .join(",");
+        output.push_str(&row);
+        output.push('\n');
+    }
+    let manifest = manifest("csv", snapshot.event_count, output.as_bytes());
+    (output, manifest)
+}
+
+fn csv(value: &str) -> String {
+    let escaped = value.replace('"', "\"\"");
+    format!("\"{escaped}\"")
+}
+
+fn manifest(format: &str, record_count: usize, bytes: &[u8]) -> ExportManifest {
+    ExportManifest {
+        schema_version: EXPORT_SCHEMA_VERSION,
+        format: format.to_string(),
+        record_count,
+        sha256: format!("{:x}", Sha256::digest(bytes)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    #[test]
+    fn empty_snapshot_exports_deterministically() {
+        let snapshot = InventorySnapshot {
+            generated_at: Utc::now(),
+            event_count: 0,
+            device_ids: Vec::new(),
+            events: Vec::new(),
+            lifetimes: Vec::new(),
+        };
+        let (left, left_manifest) = export_inventory_csv(&snapshot);
+        let (right, right_manifest) = export_inventory_csv(&snapshot);
+        assert_eq!(left, right);
+        assert_eq!(left_manifest, right_manifest);
+    }
+}

--- a/libbootforge/src/export.rs
+++ b/libbootforge/src/export.rs
@@ -22,7 +22,9 @@ pub fn export_inventory_json(snapshot: &InventorySnapshot) -> Result<(String, Ex
 }
 
 pub fn export_inventory_csv(snapshot: &InventorySnapshot) -> (String, ExportManifest) {
-    let mut output = String::from("sequence,observed_at,kind,source,device_id,vid,pid,bus,address,message\n");
+    let mut output = String::from(
+        "sequence,observed_at,kind,source,device_id,vid,pid,bus,address,message\n",
+    );
     for event in &snapshot.events {
         let row = [
             event.sequence.to_string(),
@@ -30,10 +32,10 @@ pub fn export_inventory_csv(snapshot: &InventorySnapshot) -> (String, ExportMani
             csv(&format!("{:?}", event.kind)),
             csv(&format!("{:?}", event.source)),
             csv(&event.device_id),
-            format!("{:04x}", event.vid),
-            format!("{:04x}", event.pid),
-            event.bus.map(|value| value.to_string()).unwrap_or_default(),
-            event.address.map(|value| value.to_string()).unwrap_or_default(),
+            format!("{:04x}", event.vendor_id),
+            format!("{:04x}", event.product_id),
+            event.bus_number.to_string(),
+            event.address.to_string(),
             csv(event.message.as_deref().unwrap_or_default()),
         ]
         .join(",");

--- a/libbootforge/src/inventory.rs
+++ b/libbootforge/src/inventory.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InventorySnapshot {
     pub generated_at: DateTime<Utc>,
     pub event_count: usize,
@@ -30,7 +30,7 @@ impl EventInventory {
             .or_default()
             .push(index);
         self.by_kind
-            .entry(kind_key(event.kind).to_string())
+            .entry(kind_key(&event.kind).to_string())
             .or_default()
             .push(index);
         self.lifetime.observe(&event);
@@ -56,7 +56,7 @@ impl EventInventory {
 
     pub fn events_of_kind(&self, kind: ForensicEventKind) -> Vec<&ForensicEvent> {
         self.by_kind
-            .get(kind_key(kind))
+            .get(kind_key(&kind))
             .into_iter()
             .flatten()
             .filter_map(|index| self.events.get(*index))
@@ -87,7 +87,7 @@ impl EventInventory {
     }
 }
 
-fn kind_key(kind: ForensicEventKind) -> &'static str {
+fn kind_key(kind: &ForensicEventKind) -> &'static str {
     match kind {
         ForensicEventKind::DeviceObserved => "device_observed",
         ForensicEventKind::DeviceConnected => "device_connected",

--- a/libbootforge/src/inventory.rs
+++ b/libbootforge/src/inventory.rs
@@ -1,0 +1,104 @@
+//! Deterministic, read-only in-memory inventory for forensic USB events.
+
+use crate::{DeviceLifetime, ForensicEvent, ForensicEventKind, LifetimeTracker};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InventorySnapshot {
+    pub generated_at: DateTime<Utc>,
+    pub event_count: usize,
+    pub device_ids: Vec<String>,
+    pub events: Vec<ForensicEvent>,
+    pub lifetimes: Vec<DeviceLifetime>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct EventInventory {
+    events: Vec<ForensicEvent>,
+    by_device: BTreeMap<String, Vec<usize>>,
+    by_kind: BTreeMap<String, Vec<usize>>,
+    lifetime: LifetimeTracker,
+}
+
+impl EventInventory {
+    pub fn record(&mut self, event: ForensicEvent) {
+        let index = self.events.len();
+        self.by_device
+            .entry(event.device_id.clone())
+            .or_default()
+            .push(index);
+        self.by_kind
+            .entry(kind_key(event.kind).to_string())
+            .or_default()
+            .push(index);
+        self.lifetime.observe(&event);
+        self.events.push(event);
+    }
+
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    pub fn events_for_device(&self, device_id: &str) -> Vec<&ForensicEvent> {
+        self.by_device
+            .get(device_id)
+            .into_iter()
+            .flatten()
+            .filter_map(|index| self.events.get(*index))
+            .collect()
+    }
+
+    pub fn events_of_kind(&self, kind: ForensicEventKind) -> Vec<&ForensicEvent> {
+        self.by_kind
+            .get(kind_key(kind))
+            .into_iter()
+            .flatten()
+            .filter_map(|index| self.events.get(*index))
+            .collect()
+    }
+
+    pub fn lifetime(&self, device_id: &str) -> Option<&DeviceLifetime> {
+        self.lifetime.get(device_id)
+    }
+
+    pub fn snapshot(&self, generated_at: DateTime<Utc>) -> InventorySnapshot {
+        let device_ids = self
+            .by_device
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let mut lifetimes = self.lifetime.records().cloned().collect::<Vec<_>>();
+        lifetimes.sort_by(|left, right| left.device_id.cmp(&right.device_id));
+        InventorySnapshot {
+            generated_at,
+            event_count: self.events.len(),
+            device_ids,
+            events: self.events.clone(),
+            lifetimes,
+        }
+    }
+}
+
+fn kind_key(kind: ForensicEventKind) -> &'static str {
+    match kind {
+        ForensicEventKind::DeviceObserved => "device_observed",
+        ForensicEventKind::DeviceConnected => "device_connected",
+        ForensicEventKind::DeviceDisconnected => "device_disconnected",
+        ForensicEventKind::DeviceReconnected => "device_reconnected",
+        ForensicEventKind::DeviceChanged => "device_changed",
+        ForensicEventKind::ModeChanged => "mode_changed",
+        ForensicEventKind::DriverChanged => "driver_changed",
+        ForensicEventKind::ProtocolObserved => "protocol_observed",
+        ForensicEventKind::HealthChanged => "health_changed",
+        ForensicEventKind::EnumerationFailed => "enumeration_failed",
+        ForensicEventKind::PermissionDenied => "permission_denied",
+    }
+}

--- a/libbootforge/src/lib.rs
+++ b/libbootforge/src/lib.rs
@@ -3,6 +3,9 @@
 //! Low-level, read-only-first forensic USB detection, identity correlation, protocol
 //! classification, driver visibility, health reporting, and event intelligence.
 
+pub mod anomaly;
+pub mod composite;
+pub mod descriptor_intelligence;
 pub mod detect;
 pub mod driver;
 pub mod driver_watch;
@@ -14,6 +17,7 @@ pub mod identity;
 pub mod lifetime;
 pub mod native_driver;
 pub mod notification;
+pub mod performance;
 pub mod protocol;
 pub mod recorder;
 pub mod session;
@@ -25,6 +29,11 @@ pub mod device;
 pub mod enumeration;
 pub mod events;
 
+pub use anomaly::{analyze_passively, AnomalyFinding, AnomalyKind, AnomalySeverity};
+pub use composite::{CompositeInterface, CompositeReport};
+pub use descriptor_intelligence::{
+    DecodedDescriptor, DescriptorIssue, DescriptorKind, DescriptorSnapshot, MAX_DESCRIPTOR_BYTES,
+};
 pub use detect::scanner::scan_devices;
 pub use driver::{
     ArcwyreDriverInspector, DriverBackend, DriverConfidence, DriverEvidence, DriverInspector,
@@ -45,6 +54,7 @@ pub use identity::{
 pub use lifetime::{DeviceLifetime, LifetimeTracker};
 pub use native_driver::inspect_platform_driver;
 pub use notification::{NotificationSignal, NotificationWake, PollingWake, WakeReason, WakeResult};
+pub use performance::{BoundedEventQueue, PerformanceMetrics};
 pub use protocol::{
     ProtocolConfidence, ProtocolEvidence, ProtocolObservation, ProtocolReport, UsbProtocol,
 };
@@ -96,6 +106,10 @@ mod tests {
         let _topology: Option<TopologySnapshot> = None;
         let _lifetime: Option<DeviceLifetime> = None;
         let _fingerprint: Option<ForensicFingerprint> = None;
+        let _descriptor_snapshot: Option<DescriptorSnapshot> = None;
+        let _composite: Option<CompositeReport> = None;
+        let _finding: Option<AnomalyFinding> = None;
+        let _metrics: Option<PerformanceMetrics> = None;
         let _router: fn(&DeviceInfo) -> DriverReport = inspect_platform_driver;
     }
 }

--- a/libbootforge/src/lib.rs
+++ b/libbootforge/src/lib.rs
@@ -10,6 +10,7 @@ pub mod detect;
 pub mod driver;
 pub mod driver_watch;
 pub mod error;
+pub mod export;
 pub mod fingerprint;
 pub mod forensic;
 pub mod health;
@@ -43,6 +44,9 @@ pub use driver::{
 pub use driver_watch::{DriverChange, DriverChangeField, DriverChangeMonitor, DriverStateTracker};
 pub use error::{BootforgeError, Result};
 pub use events::ForensicEventMonitor;
+pub use export::{
+    export_inventory_csv, export_inventory_json, ExportManifest, EXPORT_SCHEMA_VERSION,
+};
 pub use fingerprint::{
     ForensicFingerprint, ForensicFingerprintConfidence, ForensicFingerprintEvidence,
     FORENSIC_FINGERPRINT_SCHEMA_VERSION,
@@ -114,6 +118,7 @@ mod tests {
         let _metrics: Option<PerformanceMetrics> = None;
         let _inventory: Option<EventInventory> = None;
         let _inventory_snapshot: Option<InventorySnapshot> = None;
+        let _manifest: Option<ExportManifest> = None;
         let _router: fn(&DeviceInfo) -> DriverReport = inspect_platform_driver;
     }
 }

--- a/libbootforge/src/lib.rs
+++ b/libbootforge/src/lib.rs
@@ -14,6 +14,7 @@ pub mod fingerprint;
 pub mod forensic;
 pub mod health;
 pub mod identity;
+pub mod inventory;
 pub mod lifetime;
 pub mod native_driver;
 pub mod notification;
@@ -51,6 +52,7 @@ pub use health::{HealthReport, HealthSignal, HealthState, HealthTracker};
 pub use identity::{
     correlate_reconnect, DeviceIdentity, IdentityConfidence, IdentityEvidence, ReconnectMatch,
 };
+pub use inventory::{EventInventory, InventorySnapshot};
 pub use lifetime::{DeviceLifetime, LifetimeTracker};
 pub use native_driver::inspect_platform_driver;
 pub use notification::{NotificationSignal, NotificationWake, PollingWake, WakeReason, WakeResult};
@@ -110,6 +112,8 @@ mod tests {
         let _composite: Option<CompositeReport> = None;
         let _finding: Option<AnomalyFinding> = None;
         let _metrics: Option<PerformanceMetrics> = None;
+        let _inventory: Option<EventInventory> = None;
+        let _inventory_snapshot: Option<InventorySnapshot> = None;
         let _router: fn(&DeviceInfo) -> DriverReport = inspect_platform_driver;
     }
 }

--- a/libbootforge/src/performance.rs
+++ b/libbootforge/src/performance.rs
@@ -1,0 +1,108 @@
+//! Runtime counters for scans, event latency, queue pressure, and dropped work.
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PerformanceMetrics {
+    pub scans: u64,
+    pub events_emitted: u64,
+    pub dropped_events: u64,
+    pub peak_queue_depth: usize,
+    pub total_scan_latency_micros: u128,
+    pub total_event_latency_micros: u128,
+}
+
+impl PerformanceMetrics {
+    pub fn record_scan(&mut self, latency: Duration) {
+        self.scans = self.scans.saturating_add(1);
+        self.total_scan_latency_micros = self
+            .total_scan_latency_micros
+            .saturating_add(latency.as_micros());
+    }
+
+    pub fn record_event(&mut self, latency: Duration) {
+        self.events_emitted = self.events_emitted.saturating_add(1);
+        self.total_event_latency_micros = self
+            .total_event_latency_micros
+            .saturating_add(latency.as_micros());
+    }
+
+    pub fn record_queue_depth(&mut self, depth: usize) {
+        self.peak_queue_depth = self.peak_queue_depth.max(depth);
+    }
+
+    pub fn record_drop(&mut self, count: u64) {
+        self.dropped_events = self.dropped_events.saturating_add(count);
+    }
+
+    pub fn average_scan_latency_micros(&self) -> Option<u128> {
+        (self.scans != 0).then(|| self.total_scan_latency_micros / self.scans as u128)
+    }
+
+    pub fn average_event_latency_micros(&self) -> Option<u128> {
+        (self.events_emitted != 0)
+            .then(|| self.total_event_latency_micros / self.events_emitted as u128)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BoundedEventQueue<T> {
+    capacity: usize,
+    items: std::collections::VecDeque<T>,
+    dropped: u64,
+}
+
+impl<T> BoundedEventQueue<T> {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            items: std::collections::VecDeque::with_capacity(capacity),
+            dropped: 0,
+        }
+    }
+
+    pub fn push(&mut self, item: T) {
+        if self.capacity == 0 {
+            self.dropped = self.dropped.saturating_add(1);
+            return;
+        }
+        if self.items.len() == self.capacity {
+            self.items.pop_front();
+            self.dropped = self.dropped.saturating_add(1);
+        }
+        self.items.push_back(item);
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        self.items.pop_front()
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    pub fn dropped(&self) -> u64 {
+        self.dropped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn queue_is_bounded_and_counts_drops() {
+        let mut queue = BoundedEventQueue::new(2);
+        queue.push(1);
+        queue.push(2);
+        queue.push(3);
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue.dropped(), 1);
+        assert_eq!(queue.pop(), Some(2));
+    }
+}


### PR DESCRIPTION
## Scope

Begins the R3 mega-pass from Issue #25 on top of the green, merged R2 base.

## Implemented in this first slice

- bounded raw USB descriptor decoding
- deterministic descriptor snapshot hashing
- malformed and truncated descriptor reporting
- composite interface extraction
- alternate-setting, class, subclass, protocol, and endpoint-count modeling
- explainable passive anomaly findings
- suspicious HID/vendor-specific coexistence evidence without malware certainty claims
- missing-serial and vendor-specific-only observations
- bounded event queue with drop accounting
- scan, event, latency, and queue-pressure metrics
- public API exports and focused unit tests

## Safety boundary

Read-only analysis only. No active probing, formatting, flashing, driver mutation, device control, unlocking, filesystem writes, or blocking behavior.

## Next slices under this PR

- Interface Association Descriptor grouping
- endpoint graph and per-interface protocol evidence
- persistent lifetime and event inventory
- deterministic CSV and SQLite evidence contracts
- serial, VID/PID, descriptor-layout, reconnect-timing, and enumeration-storm anomaly trackers
- descriptor and evidence fuzz targets
- benchmark and clean-shutdown foundations

## Validation

- implemented: yes
- integrated: first slice
- hosted CI: pending
- hardware validated: no
- release candidate: no
